### PR TITLE
Add game retrieval endpoint and set custom favicon

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,8 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/gif" href="/personahaticon.gif" />
+    <link rel="apple-touch-icon" href="/personahaticon.gif" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + React</title>
   </head>

--- a/server.js
+++ b/server.js
@@ -139,6 +139,32 @@ app.post('/api/games', requireAuth, async (req, res) => {
     res.json(game);
 });
 
+app.get('/api/games/:id', requireAuth, async (req, res) => {
+    const { id } = req.params || {};
+    const db = await readDB();
+    const g = (db.games || []).find(g => g && g.id === id);
+    if (!g || !Array.isArray(g.players) || !g.players.some(p => p.userId === req.session.userId)) {
+        return res.status(404).json({ error: 'not_found' });
+    }
+
+    const out = {
+        id: g.id,
+        name: g.name,
+        dmId: g.dmId,
+        players: Array.isArray(g.players) ? g.players : [],
+        items: g.items && typeof g.items === 'object' ? g.items : { custom: [] },
+        gear: g.gear && typeof g.gear === 'object' ? g.gear : { custom: [] },
+        demons: Array.isArray(g.demons) ? g.demons : [],
+        demonPool: g.demonPool && typeof g.demonPool === 'object' ? g.demonPool : { max: 0, used: 0 },
+        permissions: g.permissions && typeof g.permissions === 'object'
+            ? g.permissions
+            : { canEditStats: false, canEditItems: false, canEditGear: false, canEditDemons: false },
+        invites: Array.isArray(g.invites) ? g.invites : [],
+    };
+
+    res.json(out);
+});
+
 // (the rest of your routes unchanged, but add the same style of defensive checks on g.players, etc.)
 
 // --- Items ---


### PR DESCRIPTION
## Summary
- Serve `personahaticon.gif` as the site's favicon
- Add an authenticated GET `/api/games/:id` endpoint for retrieving game details with defensive checks

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Cannot find package '@eslint/js')

------
https://chatgpt.com/codex/tasks/task_e_68c564dc1e3c8331b47856f3baa53e99