### PR TITLE
Add invite support, editing flows, and matrix rain overhaul

### DIFF
--- a/dev.js
+++ b/dev.js
@@ -1,3 +1,5 @@
+/* eslint-env node */
+import process from 'process';
 import { spawn } from 'child_process';
 
 const server = spawn('node', ['server.js'], { stdio: 'inherit' });

--- a/web/src/MatrixRain.jsx
+++ b/web/src/MatrixRain.jsx
@@ -1,27 +1,86 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { onApiActivity } from './api';
+
+const COLUMN_COUNT = 28;
+const GLYPHS = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+const ROWS = 32;
+
+function randomGlyph() {
+    return GLYPHS[Math.floor(Math.random() * GLYPHS.length)];
+}
 
 // Simple matrix-style rain shown when API requests are active
 export default function MatrixRain() {
     const [active, setActive] = useState(false);
+    const [visible, setVisible] = useState(false);
+    const [columns, setColumns] = useState(() => []);
+    const fadeTimer = useRef(null);
 
     useEffect(() => onApiActivity(setActive), []);
 
-    if (!active) return null;
+    useEffect(() => {
+        if (active) {
+            setVisible(true);
+            setColumns(() =>
+                Array.from({ length: COLUMN_COUNT }, (_, i) => ({
+                    id: i,
+                    left: Math.random() * 100,
+                    duration: 1.6 + Math.random() * 1.8,
+                    delay: Math.random() * 1.5,
+                    chars: Array.from({ length: ROWS }, randomGlyph),
+                }))
+            );
+        } else {
+            if (fadeTimer.current) clearTimeout(fadeTimer.current);
+            fadeTimer.current = setTimeout(() => setVisible(false), 400);
+        }
+        return () => {
+            if (fadeTimer.current) {
+                clearTimeout(fadeTimer.current);
+                fadeTimer.current = null;
+            }
+        };
+    }, [active]);
 
-    const columns = Array.from({ length: 20 }, (_, i) => (
-        <div
-            key={i}
-            className="matrix-column"
-            style={{
-                left: `${Math.random() * 100}%`,
-                animationDuration: `${1 + Math.random() * 2}s`,
-            }}
-        >
-            {Array.from({ length: 40 }, () => Math.floor(Math.random() * 10)).join('')}
+    useEffect(() => {
+        if (!active) return undefined;
+        const interval = setInterval(() => {
+            setColumns((cols) =>
+                cols.map((col) => ({
+                    ...col,
+                    chars: [randomGlyph(), ...col.chars.slice(0, ROWS - 1)],
+                }))
+            );
+        }, 120);
+        return () => clearInterval(interval);
+    }, [active]);
+
+    const content = useMemo(() => (
+        columns.map((col) => (
+            <div
+                key={col.id}
+                className="matrix-column"
+                style={{
+                    left: `${col.left}%`,
+                    animationDuration: `${col.duration}s`,
+                    animationDelay: `${col.delay}s`,
+                }}
+            >
+                {col.chars.map((char, idx) => (
+                    <span key={idx} className="matrix-char" style={{ opacity: Math.max(0.25, idx / ROWS) }}>
+                        {char}
+                    </span>
+                ))}
+            </div>
+        ))
+    ), [columns]);
+
+    if (!visible) return null;
+
+    return (
+        <div className={`matrix-rain${active ? ' active' : ''}`} aria-hidden>
+            {content}
         </div>
-    ));
-
-    return <div className="matrix-rain">{columns}</div>;
+    );
 }
 

--- a/web/src/api.js
+++ b/web/src/api.js
@@ -403,8 +403,13 @@ export const Games = {
     setPerms: (id, perms) => api(`/api/games/${encodeURIComponent(id)}/permissions`, { method: 'PUT', body: perms }),
     saveCharacter: (id, character) => api(`/api/games/${encodeURIComponent(id)}/character`, { method: 'PUT', body: { character } }),
     addCustomItem: (id, item) => api(`/api/games/${encodeURIComponent(id)}/items/custom`, { method: 'POST', body: { item } }),
+    updateCustomItem: (id, itemId, item) => api(`/api/games/${encodeURIComponent(id)}/items/custom/${encodeURIComponent(itemId)}`, { method: 'PUT', body: { item } }),
+    deleteCustomItem: (id, itemId) => api(`/api/games/${encodeURIComponent(id)}/items/custom/${encodeURIComponent(itemId)}`, { method: 'DELETE' }),
     addCustomGear: (id, item) => api(`/api/games/${encodeURIComponent(id)}/gear/custom`, { method: 'POST', body: { item } }),
+    updateCustomGear: (id, itemId, item) => api(`/api/games/${encodeURIComponent(id)}/gear/custom/${encodeURIComponent(itemId)}`, { method: 'PUT', body: { item } }),
+    deleteCustomGear: (id, itemId) => api(`/api/games/${encodeURIComponent(id)}/gear/custom/${encodeURIComponent(itemId)}`, { method: 'DELETE' }),
     addDemon: (id, body) => api(`/api/games/${encodeURIComponent(id)}/demons`, { method: 'POST', body }),
+    updateDemon: (id, demonId, body) => api(`/api/games/${encodeURIComponent(id)}/demons/${encodeURIComponent(demonId)}`, { method: 'PUT', body }),
     delDemon: (id, demonId) => api(`/api/games/${encodeURIComponent(id)}/demons/${encodeURIComponent(demonId)}`, { method: 'DELETE' }),
 
     // Optional: full pagination helper example if the backend supports it

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -440,18 +440,31 @@ pre  { padding: 12px; overflow: auto; }
     position: fixed;
     inset: 0;
     pointer-events: none;
-    background: rgba(0,0,0,0.4);
+    background: rgba(0,0,0,0.45);
     font-family: monospace;
     color: #0f0;
     z-index: 1000;
     overflow: hidden;
+    opacity: 0;
+    transition: opacity 180ms ease;
+}
+.matrix-rain.active {
+    opacity: 1;
 }
 .matrix-column {
     position: absolute;
-    top: -100%;
-    white-space: nowrap;
+    top: -120%;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
     animation: matrix-fall linear infinite;
-    opacity: 0.7;
+    opacity: 0.85;
+}
+.matrix-char {
+    display: block;
+    font-size: 14px;
+    line-height: 1;
+    text-shadow: 0 0 6px rgba(0, 255, 0, 0.45);
 }
 @keyframes matrix-fall {
     to { transform: translateY(200%); }


### PR DESCRIPTION
## Summary
- add full server support for invite codes, permissions, and CRUD endpoints for custom items, gear, and demons
- enable editing, removal, and detailed demon configuration from the UI while refreshing the Matrix rain activity indicator

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf5aa357188331abb67c829f9989c3