### PR TITLE
Fix dev script double-starting Vite

### DIFF
--- a/dev.js
+++ b/dev.js
@@ -3,15 +3,14 @@ import process from 'process';
 import { spawn } from 'child_process';
 
 const server = spawn('node', ['server.js'], { stdio: 'inherit' });
-const client = spawn('node', ['node_modules/vite/bin/vite.js'], { stdio: 'inherit' });
 
 function close() {
-  server.kill();
-  client.kill();
+  if (!server.killed) {
+    server.kill();
+  }
 }
 
 server.on('exit', code => { close(); process.exit(code ?? 0); });
-client.on('exit', code => { close(); process.exit(code ?? 0); });
 
 process.on('SIGINT', () => close());
 process.on('SIGTERM', () => close());


### PR DESCRIPTION
## Summary
- update the development helper script to only spawn the API server
- guard the shutdown routine so it only terminates the server when needed

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf6a93f868833188bbc7042703b638