### PR TITLE
Improve invite flow with clipboard copy

### DIFF
--- a/web/src/style.css
+++ b/web/src/style.css
@@ -217,6 +217,73 @@ p  { margin: 0 0 .75rem; color: var(--text); }
     --btn-fg: var(--text);
     border: 1px solid var(--border);
 }
+
+/* Invite feedback */
+.invite-button {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    align-items: flex-end;
+    position: relative;
+}
+
+.invite-feedback {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    box-shadow: var(--shadow-sm);
+    padding: 12px 14px;
+    width: min(320px, 90vw);
+    text-align: left;
+    animation: fade-in-up var(--trans) ease;
+}
+
+.invite-feedback strong {
+    color: var(--brand-600);
+    font-size: .95rem;
+}
+
+.invite-feedback__row {
+    display: grid;
+    gap: 4px;
+    margin-top: 8px;
+}
+
+.invite-feedback__row span {
+    color: var(--muted);
+    font-size: .75rem;
+    text-transform: uppercase;
+    letter-spacing: .04em;
+}
+
+.invite-feedback__row code {
+    display: block;
+    background: var(--surface-2);
+    padding: 6px 8px;
+    border-radius: var(--radius-sm);
+    font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+    font-size: .8rem;
+    border: 1px dashed var(--border);
+    word-break: break-word;
+}
+
+.invite-feedback__note {
+    display: block;
+    margin-top: 8px;
+    font-size: .8rem;
+    color: var(--muted);
+}
+
+@keyframes fade-in-up {
+    from {
+        opacity: 0;
+        transform: translateY(6px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
 .btn.ghost {
     background: transparent;
     color: var(--brand);


### PR DESCRIPTION
## Summary
- copy newly generated invite links to the clipboard with graceful fallback handling
- present invite code and link details in a styled status panel instead of an alert
- auto-dismiss the invite panel after a short delay so the UI stays tidy

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf6c1021d08331bd3ab2922c745f81