### PR TITLE
Fix express error handler signature

### DIFF
--- a/server.js
+++ b/server.js
@@ -910,7 +910,10 @@ app.use(express.static(path.join(__dirname, 'public')));
 app.use(express.static(path.join(__dirname, 'dist')));
 
 // centralized error handler (prevents crashing the process)
-app.use((err, _req, res) => {
+app.use((err, _req, res, next) => {
+    if (res.headersSent) {
+        return next(err);
+    }
     console.error(err);
     res.status(500).json({ error: 'server_error' });
 });


### PR DESCRIPTION
## Summary
- ensure the Express error-handling middleware uses the correct four-argument signature
- avoid double-sending responses by delegating to the default handler when headers were already sent

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf75ab598c8331be96bece06c423d6