### PR TITLE
Add game deletion controls and DM sheet management

### DIFF
--- a/web/src/api.js
+++ b/web/src/api.js
@@ -399,6 +399,7 @@ export const Games = {
     create: (name) => api('/api/games', { method: 'POST', body: { name } }),
     get: (id) => api(`/api/games/${encodeURIComponent(id)}`, { cache: 2000 }),
     invite: (id) => api(`/api/games/${encodeURIComponent(id)}/invites`, { method: 'POST' }),
+    delete: (id) => api(`/api/games/${encodeURIComponent(id)}`, { method: 'DELETE' }),
     joinByCode: (code) => api(`/api/games/join/${encodeURIComponent(code)}`, { method: 'POST' }),
     setPerms: (id, perms) => api(`/api/games/${encodeURIComponent(id)}/permissions`, { method: 'PUT', body: perms }),
     saveCharacter: (id, character) => api(`/api/games/${encodeURIComponent(id)}/character`, { method: 'PUT', body: { character } }),


### PR DESCRIPTION
## Summary
- add a DELETE /api/games/:id route and API helper to remove campaigns
- allow DMs to delete campaigns from the home list and in-game settings
- let DMs select party members to view and edit their character sheets

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf7be9e88083319b676c7a33f765e4