### PR TITLE
Allow DMs to delete games

### DIFF
--- a/server.js
+++ b/server.js
@@ -107,12 +107,14 @@ function saveGame(db, updated) {
     db.games[idx] = updated;
 }
 
-function isMember(game, userId) {
-    return Array.isArray(game.players) && game.players.some((p) => p && p.userId === userId);
-}
-
 function isDM(game, userId) {
     return game.dmId === userId;
+}
+
+function isMember(game, userId) {
+    if (!userId) return false;
+    if (isDM(game, userId)) return true;
+    return Array.isArray(game.players) && game.players.some((p) => p && p.userId === userId);
 }
 
 function ensureInviteList(game) {


### PR DESCRIPTION
## Summary
- count the dungeon master as a game member when checking permissions so DM-only actions like delete work even if they are not in the players list

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf7ed569d083319072319693b6a872