### PR TITLE
Overhaul campaign UI with DM and player modes

### DIFF
--- a/web/src/style.css
+++ b/web/src/style.css
@@ -100,7 +100,8 @@ body {
 }
 
 #root {
-    padding: 20px;
+    min-height: 100vh;
+    padding: clamp(16px, 3vw, 32px);
 }
 
 /* Typography */
@@ -191,20 +192,42 @@ p  { margin: 0 0 .75rem; color: var(--text); }
     --btn-bg-hover: var(--brand-600);
     --btn-bg-active: var(--brand-700);
     --btn-fg: #fff;
+    --btn-border: transparent;
+    --btn-border-hover: transparent;
+    --btn-border-active: transparent;
     --btn-ring: var(--focus);
 
     background: var(--btn-bg);
     color: var(--btn-fg);
-    border: none;
-    padding: 8px 14px;
+    border: 1px solid var(--btn-border);
+    padding: 8px 16px;
     border-radius: var(--radius-sm);
     cursor: pointer;
-    transition: transform var(--trans-fast), background var(--trans-fast), box-shadow var(--trans-fast), opacity var(--trans-fast);
-    box-shadow: 0 1px 1px rgba(0,0,0,.05);
+    font-weight: 600;
+    letter-spacing: .01em;
+    line-height: 1.1;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    transition:
+        transform var(--trans-fast),
+        background var(--trans-fast),
+        box-shadow var(--trans-fast),
+        opacity var(--trans-fast),
+        border-color var(--trans-fast);
+    box-shadow: 0 1px 1px rgba(0, 0, 0, .05);
     user-select: none;
 }
-.btn:hover { background: var(--btn-bg-hover); }
-.btn:active { background: var(--btn-bg-active); transform: translateY(1px); }
+.btn:hover {
+    background: var(--btn-bg-hover);
+    border-color: var(--btn-border-hover);
+}
+.btn:active {
+    background: var(--btn-bg-active);
+    border-color: var(--btn-border-active);
+    transform: translateY(1px);
+}
 .btn:focus-visible { outline: none; box-shadow: var(--btn-ring); }
 .btn:disabled,
 .btn[disabled] { opacity: .6; cursor: not-allowed; transform: none; }
@@ -215,7 +238,9 @@ p  { margin: 0 0 .75rem; color: var(--text); }
     --btn-bg-hover: #e5e7eb;
     --btn-bg-active: #d1d5db;
     --btn-fg: var(--text);
-    border: 1px solid var(--border);
+    --btn-border: var(--border);
+    --btn-border-hover: color-mix(in oklab, var(--border) 60%, var(--brand) 40%);
+    --btn-border-active: color-mix(in oklab, var(--border) 40%, var(--brand) 60%);
 }
 
 /* Invite feedback */
@@ -285,17 +310,24 @@ p  { margin: 0 0 .75rem; color: var(--text); }
     }
 }
 .btn.ghost {
-    background: transparent;
-    color: var(--brand);
-    border: 1px solid transparent;
-}
-.btn.ghost:hover {
-    background: color-mix(in oklab, var(--brand) 10%, transparent);
-    border-color: color-mix(in oklab, var(--brand) 30%, transparent);
+    --btn-bg: transparent;
+    --btn-bg-hover: color-mix(in oklab, var(--brand) 12%, transparent);
+    --btn-bg-active: color-mix(in oklab, var(--brand) 24%, transparent);
+    --btn-fg: var(--brand-600);
+    --btn-border: color-mix(in oklab, var(--brand) 38%, transparent);
+    --btn-border-hover: color-mix(in oklab, var(--brand) 48%, transparent);
+    --btn-border-active: color-mix(in oklab, var(--brand) 58%, transparent);
+    box-shadow: none;
 }
 .btn.success { --btn-bg: var(--success); --btn-bg-hover: #15803d; --btn-bg-active: #166534; }
 .btn.warn    { --btn-bg: var(--warning); --btn-bg-hover: #d97706; --btn-bg-active: #b45309; }
 .btn.danger  { --btn-bg: var(--danger); --btn-bg-hover: #dc2626; --btn-bg-active: #b91c1c; }
+
+.btn.btn-small {
+    padding: 6px 12px;
+    font-size: .8rem;
+    border-radius: calc(var(--radius-sm) - 2px);
+}
 
 /* Icon button */
 .icon-btn {
@@ -338,6 +370,392 @@ p  { margin: 0 0 .75rem; color: var(--text); }
     border-color: var(--brand);
     color: var(--text);
     background: var(--surface);
+}
+
+/* Application shell */
+.app-shell {
+    display: grid;
+    grid-template-columns: minmax(260px, 320px) minmax(0, 1fr);
+    gap: 28px;
+    min-height: calc(100vh - clamp(16px, 3vw, 32px) * 2);
+}
+
+@media (max-width: 960px) {
+    .app-shell {
+        grid-template-columns: 1fr;
+    }
+}
+
+.app-sidebar {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-md);
+    padding: 28px 22px;
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+}
+
+.app-sidebar .btn {
+    width: 100%;
+}
+
+.sidebar__header {
+    display: grid;
+    gap: 6px;
+}
+
+.sidebar__mode {
+    font-size: .72rem;
+    letter-spacing: .18em;
+    text-transform: uppercase;
+    color: var(--brand-600);
+    font-weight: 700;
+}
+
+.sidebar__title {
+    margin: 4px 0;
+}
+
+.sidebar__summary {
+    color: var(--muted);
+    font-size: .9rem;
+    line-height: 1.45;
+    margin: 0;
+}
+
+.sidebar__nav {
+    display: grid;
+    gap: 8px;
+}
+
+.sidebar__nav-button {
+    text-align: left;
+    border-radius: var(--radius);
+    padding: 14px 16px;
+    background: transparent;
+    border: 1px solid transparent;
+    display: grid;
+    gap: 4px;
+    color: var(--muted);
+    font-size: .92rem;
+    transition:
+        background var(--trans-fast),
+        border-color var(--trans-fast),
+        color var(--trans-fast),
+        transform var(--trans-fast),
+        box-shadow var(--trans-fast);
+}
+
+.sidebar__nav-button:hover {
+    background: var(--surface-2);
+    border-color: var(--border);
+    color: var(--text);
+}
+
+.sidebar__nav-button.is-active {
+    background: color-mix(in oklab, var(--brand) 8%, var(--surface));
+    border-color: color-mix(in oklab, var(--brand) 45%, transparent);
+    box-shadow: var(--shadow-sm);
+    color: var(--text);
+}
+
+.sidebar__nav-label {
+    font-weight: 600;
+}
+
+.sidebar__nav-desc {
+    font-size: .78rem;
+    color: var(--muted);
+    line-height: 1.4;
+}
+
+.sidebar__footer {
+    margin-top: auto;
+    display: grid;
+    gap: 12px;
+}
+
+.app-sidebar .invite-button {
+    width: 100%;
+    align-items: stretch;
+}
+
+.app-sidebar .invite-button > .btn {
+    width: 100%;
+    justify-content: center;
+}
+
+.app-main {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+}
+
+.app-main__header {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    padding: 24px;
+    box-shadow: var(--shadow-sm);
+    display: flex;
+    justify-content: space-between;
+    gap: 24px;
+    align-items: flex-start;
+}
+
+@media (max-width: 720px) {
+    .app-main__header {
+        flex-direction: column;
+    }
+}
+
+.eyebrow {
+    display: inline-block;
+    font-size: .72rem;
+    letter-spacing: .18em;
+    text-transform: uppercase;
+    color: var(--brand-600);
+    font-weight: 700;
+    margin-bottom: 6px;
+}
+
+.text-muted { color: var(--muted); }
+.text-small { font-size: .85rem; line-height: 1.4; }
+
+.app-main__header-meta {
+    display: grid;
+    gap: 12px;
+    justify-items: end;
+}
+
+.header-pills {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    justify-content: flex-end;
+}
+
+.header-player {
+    display: grid;
+    gap: 2px;
+    text-align: right;
+}
+
+.header-player strong {
+    font-size: 1rem;
+}
+
+.app-content {
+    display: grid;
+    gap: 20px;
+}
+
+@media (max-width: 960px) {
+    .app-sidebar {
+        border-radius: var(--radius);
+        padding: 24px 20px;
+    }
+
+    .app-main__header-meta {
+        justify-items: start;
+    }
+
+    .header-pills {
+        justify-content: flex-start;
+    }
+}
+
+/* Party list */
+.party-roster {
+    display: grid;
+    gap: 12px;
+}
+
+.party-row {
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 12px 16px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    transition:
+        background var(--trans-fast),
+        border-color var(--trans-fast),
+        box-shadow var(--trans-fast),
+        transform var(--trans-fast);
+}
+
+.party-row__info {
+    display: grid;
+    gap: 4px;
+    min-width: 0;
+}
+
+.party-row__name {
+    font-weight: 600;
+    font-size: 1rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.party-row__metrics {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    align-items: center;
+    justify-content: flex-end;
+}
+
+.party-row.is-clickable {
+    cursor: pointer;
+}
+
+.party-row.is-clickable:hover {
+    border-color: color-mix(in oklab, var(--brand) 45%, transparent);
+    background: color-mix(in oklab, var(--brand) 6%, var(--surface));
+}
+
+.party-row.is-active {
+    border-color: color-mix(in oklab, var(--brand) 55%, transparent);
+    background: color-mix(in oklab, var(--brand) 10%, var(--surface));
+    box-shadow: var(--shadow-sm);
+}
+
+.party-row:focus-visible {
+    outline: none;
+    box-shadow: var(--focus);
+}
+
+@media (max-width: 640px) {
+    .party-row {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .party-row__metrics {
+        justify-content: flex-start;
+    }
+}
+
+/* DM overview */
+.dm-overview {
+    gap: 20px;
+}
+
+.overview-metrics {
+    display: grid;
+    gap: 12px;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.metric-card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 16px;
+    display: grid;
+    gap: 6px;
+    box-shadow: var(--shadow-sm);
+}
+
+.metric-card__value {
+    font-size: 1.6rem;
+    font-weight: 700;
+}
+
+.overview-roster {
+    gap: 12px;
+}
+
+.overview-player {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    gap: 16px;
+    align-items: center;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 14px 16px;
+    background: var(--surface-2);
+    transition:
+        background var(--trans-fast),
+        border-color var(--trans-fast),
+        box-shadow var(--trans-fast),
+        transform var(--trans-fast);
+}
+
+.overview-player__info {
+    display: grid;
+    gap: 4px;
+    min-width: 0;
+}
+
+.overview-player__name {
+    font-weight: 600;
+    font-size: 1.05rem;
+}
+
+.overview-player__meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    align-items: center;
+    justify-content: flex-end;
+}
+
+.overview-player.is-clickable {
+    cursor: pointer;
+}
+
+.overview-player.is-clickable:hover {
+    border-color: color-mix(in oklab, var(--brand) 45%, transparent);
+    background: color-mix(in oklab, var(--brand) 6%, var(--surface));
+}
+
+.overview-player:focus-visible {
+    outline: none;
+    box-shadow: var(--focus);
+}
+
+.overview-resources {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.resource-grid {
+    display: grid;
+    gap: 12px;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.resource-chip {
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 14px 16px;
+    display: grid;
+    gap: 4px;
+    background: var(--surface-2);
+    box-shadow: var(--shadow-sm);
+}
+
+.resource-chip strong {
+    font-size: 1.3rem;
+}
+
+@media (max-width: 640px) {
+    .overview-player {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .overview-player__meta {
+        justify-content: flex-start;
+    }
 }
 
 /* Pills / badges */


### PR DESCRIPTION
## Summary
- introduce dedicated navigation for Dungeon Masters and players and split the authenticated flow into focused components for the home screen and in-session dashboard
- add a Dungeon Master overview surface that highlights party metrics, a selectable roster, and campaign resource summaries to keep sensitive tools separate from the player view
- refresh the layout with a sidebar shell, updated header metadata, refined party list interactions, and button variants for a cleaner presentation

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d0081269f88331b0a1353e061cbbe1