### PR TITLE
Restrict demon management actions to DMs

### DIFF
--- a/server.js
+++ b/server.js
@@ -877,7 +877,7 @@ app.post('/api/games/:id/demons', requireAuth, async (req, res) => {
     if (!game || !isMember(game, req.session.userId)) {
         return res.status(404).json({ error: 'not_found' });
     }
-    if (!isDM(game, req.session.userId) && !game.permissions.canEditDemons) {
+    if (!isDM(game, req.session.userId)) {
         return res.status(403).json({ error: 'forbidden' });
     }
 
@@ -967,7 +967,7 @@ app.delete('/api/games/:id/demons/:demonId', requireAuth, async (req, res) => {
     if (!game || !isMember(game, req.session.userId)) {
         return res.status(404).json({ error: 'not_found' });
     }
-    if (!isDM(game, req.session.userId) && !game.permissions.canEditDemons) {
+    if (!isDM(game, req.session.userId)) {
         return res.status(403).json({ error: 'forbidden' });
     }
 


### PR DESCRIPTION
## Summary
- prevent non-DM players from adding demons or using the compendium search while keeping edit access
- require DM privileges on the server before creating or deleting demons from the pool

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d0110f6dd48331bc4ca310f9f072e7