### PR TITLE
Allow DMs to remove players from a campaign

### DIFF
--- a/web/src/api.js
+++ b/web/src/api.js
@@ -409,6 +409,7 @@ export const Games = {
     addPlayerItem: (id, playerId, item) => api(`/api/games/${encodeURIComponent(id)}/players/${encodeURIComponent(playerId)}/items`, { method: 'POST', body: { item } }),
     updatePlayerItem: (id, playerId, itemId, item) => api(`/api/games/${encodeURIComponent(id)}/players/${encodeURIComponent(playerId)}/items/${encodeURIComponent(itemId)}`, { method: 'PUT', body: { item } }),
     deletePlayerItem: (id, playerId, itemId) => api(`/api/games/${encodeURIComponent(id)}/players/${encodeURIComponent(playerId)}/items/${encodeURIComponent(itemId)}`, { method: 'DELETE' }),
+    removePlayer: (id, playerId) => api(`/api/games/${encodeURIComponent(id)}/players/${encodeURIComponent(playerId)}`, { method: 'DELETE' }),
     setPlayerGear: (id, playerId, slot, item) => api(`/api/games/${encodeURIComponent(id)}/players/${encodeURIComponent(playerId)}/gear/${encodeURIComponent(slot)}`, { method: 'PUT', body: { item } }),
     clearPlayerGear: (id, playerId, slot) => api(`/api/games/${encodeURIComponent(id)}/players/${encodeURIComponent(playerId)}/gear/${encodeURIComponent(slot)}`, { method: 'DELETE' }),
     addCustomGear: (id, item) => api(`/api/games/${encodeURIComponent(id)}/gear/custom`, { method: 'POST', body: { item } }),


### PR DESCRIPTION
## Summary
- add a secured API endpoint that lets dungeon masters remove players from a campaign roster
- expose a Games.removePlayer client helper and surface member management controls in the campaign settings view
- refresh the active game and dm sheet selection after removing a player to keep the UI in sync

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d020f478b08331a04c129e326881d4