### PR TITLE
Tweak MatrixRain update rate

### DIFF
--- a/web/src/MatrixRain.jsx
+++ b/web/src/MatrixRain.jsx
@@ -51,7 +51,7 @@ export default function MatrixRain() {
                     chars: [randomGlyph(), ...col.chars.slice(0, ROWS - 1)],
                 }))
             );
-        }, 120);
+        }, 95);
         return () => clearInterval(interval);
     }, [active]);
 


### PR DESCRIPTION
## Summary
- make the MatrixRain column updates run slightly faster so the effect appears more frequently while staying readable

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d023631304833198d7a11d7fb3cfb7