### PR TITLE
Revamp gear management and improve UI

### DIFF
--- a/web/src/api.js
+++ b/web/src/api.js
@@ -410,7 +410,26 @@ export const Games = {
     updatePlayerItem: (id, playerId, itemId, item) => api(`/api/games/${encodeURIComponent(id)}/players/${encodeURIComponent(playerId)}/items/${encodeURIComponent(itemId)}`, { method: 'PUT', body: { item } }),
     deletePlayerItem: (id, playerId, itemId) => api(`/api/games/${encodeURIComponent(id)}/players/${encodeURIComponent(playerId)}/items/${encodeURIComponent(itemId)}`, { method: 'DELETE' }),
     removePlayer: (id, playerId) => api(`/api/games/${encodeURIComponent(id)}/players/${encodeURIComponent(playerId)}`, { method: 'DELETE' }),
-    setPlayerGear: (id, playerId, slot, item) => api(`/api/games/${encodeURIComponent(id)}/players/${encodeURIComponent(playerId)}/gear/${encodeURIComponent(slot)}`, { method: 'PUT', body: { item } }),
+    addPlayerGearBag: (id, playerId, item) =>
+        api(`/api/games/${encodeURIComponent(id)}/players/${encodeURIComponent(playerId)}/gear/bag`, {
+            method: 'POST',
+            body: { item },
+        }),
+    updatePlayerGearBag: (id, playerId, itemId, item) =>
+        api(
+            `/api/games/${encodeURIComponent(id)}/players/${encodeURIComponent(playerId)}/gear/bag/${encodeURIComponent(itemId)}`,
+            { method: 'PUT', body: { item } }
+        ),
+    deletePlayerGearBag: (id, playerId, itemId) =>
+        api(
+            `/api/games/${encodeURIComponent(id)}/players/${encodeURIComponent(playerId)}/gear/bag/${encodeURIComponent(itemId)}`,
+            { method: 'DELETE' }
+        ),
+    setPlayerGear: (id, playerId, slot, payload) =>
+        api(`/api/games/${encodeURIComponent(id)}/players/${encodeURIComponent(playerId)}/gear/${encodeURIComponent(slot)}`, {
+            method: 'PUT',
+            body: payload,
+        }),
     clearPlayerGear: (id, playerId, slot) => api(`/api/games/${encodeURIComponent(id)}/players/${encodeURIComponent(playerId)}/gear/${encodeURIComponent(slot)}`, { method: 'DELETE' }),
     addCustomGear: (id, item) => api(`/api/games/${encodeURIComponent(id)}/gear/custom`, { method: 'POST', body: { item } }),
     updateCustomGear: (id, itemId, item) => api(`/api/games/${encodeURIComponent(id)}/gear/custom/${encodeURIComponent(itemId)}`, { method: 'PUT', body: { item } }),

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -373,6 +373,44 @@ p  { margin: 0 0 .75rem; color: var(--text); }
 }
 
 /* Application shell */
+.app-root {
+    display: grid;
+    gap: 16px;
+}
+
+.app-activity {
+    height: 3px;
+    border-radius: 999px;
+    background: var(--border);
+    overflow: hidden;
+    position: relative;
+    opacity: 0;
+    transition: opacity var(--trans-fast);
+}
+
+.app-activity__bar {
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(90deg, var(--brand-600), var(--brand));
+    transform-origin: left;
+    transform: scaleX(0);
+    transition: transform var(--trans-fast);
+}
+
+.app-activity.is-active {
+    opacity: 1;
+}
+
+.app-activity.is-active .app-activity__bar {
+    transform: scaleX(1);
+    animation: activity-pulse 1.2s ease-in-out infinite;
+}
+
+@keyframes activity-pulse {
+    from { opacity: 0.45; }
+    to { opacity: 1; }
+}
+
 .app-shell {
     display: grid;
     grid-template-columns: minmax(260px, 320px) minmax(0, 1fr);
@@ -529,6 +567,22 @@ p  { margin: 0 0 .75rem; color: var(--text); }
     display: grid;
     gap: 12px;
     justify-items: end;
+}
+
+.header-actions {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+}
+
+.header-actions .btn {
+    white-space: nowrap;
+}
+
+.hotkey-hint {
+    opacity: 0.75;
 }
 
 .header-pills {


### PR DESCRIPTION
## Summary
- normalize stored gear into bag/slot state and add endpoints to manage gear bags and equipping
- refresh the game view shell with activity indicators, hotkeys, and persistence
- rebuild the player gear card for large inventories with search, quick actions, and library imports

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d02472f06c83319ce942d49e7cfb8b