### PR TITLE
Add story logs tab with Discord channel embed

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Discord story log embed configuration for Vite
+VITE_DISCORD_SERVER_ID=
+VITE_DISCORD_CHANNEL_ID=
+
+# Optional overrides
+VITE_DISCORD_WIDGET_BASE=https://e.widgetbot.io/channels
+VITE_DISCORD_WIDGET_THEME=dark

--- a/README.md
+++ b/README.md
@@ -10,3 +10,18 @@ Currently, two official plugins are available:
 ## Expanding the ESLint configuration
 
 If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+
+## Discord story log embed
+
+The in-app **Story Logs** tab displays a live Discord channel feed. Configure the following environment variables (e.g. in a `.env` file loaded by Vite) so the widget knows which guild and channel to show:
+
+```
+VITE_DISCORD_SERVER_ID=<your discord guild/server id>
+VITE_DISCORD_CHANNEL_ID=<the story log channel id>
+
+# Optional overrides
+VITE_DISCORD_WIDGET_BASE=https://e.widgetbot.io/channels
+VITE_DISCORD_WIDGET_THEME=dark
+```
+
+Restart the Vite dev server after editing the variables so the client receives the updated values.

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -607,6 +607,37 @@ p  { margin: 0 0 .75rem; color: var(--text); }
     gap: 20px;
 }
 
+/* Story logs */
+.story-logs-card {
+    display: grid;
+    gap: 16px;
+}
+
+.story-logs__embed {
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    overflow: hidden;
+    background: #0b0d17;
+}
+
+.story-logs__embed iframe {
+    display: block;
+    width: 100%;
+    height: clamp(420px, 70vh, 760px);
+    border: 0;
+}
+
+.story-logs__empty {
+    padding: 24px;
+    border: 1px dashed color-mix(in srgb, var(--border) 75%, transparent);
+    border-radius: var(--radius);
+    background: color-mix(in srgb, var(--surface) 85%, transparent);
+}
+
+.story-logs__empty p {
+    margin: 0;
+}
+
 @media (max-width: 960px) {
     .app-sidebar {
         border-radius: var(--radius);


### PR DESCRIPTION
## Summary
- add a Story Logs navigation item for both DM and player views
- render a Discord-powered story log tab that reads the channel and handles missing env configuration gracefully
- document the required Vite environment variables and provide styling for the embedded feed
- include a .env.example template with the Discord Story Log variables

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d02ce0954c8331a436549596a8c78b