### PR TITLE
Add Discord story log watcher and UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,17 +11,18 @@ Currently, two official plugins are available:
 
 If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
 
-## Discord story log embed
+## Discord story log sync
 
-The in-app **Story Logs** tab displays a live Discord channel feed. Configure the following environment variables (e.g. in a `.env` file loaded by Vite) so the widget knows which guild and channel to show:
+The in-app **Story Logs** tab now reads messages through the backend. Provide a Discord bot token with permission to view the story log channel and configure the server with the following environment variables before starting `node server.js`:
 
 ```
-VITE_DISCORD_SERVER_ID=<your discord guild/server id>
-VITE_DISCORD_CHANNEL_ID=<the story log channel id>
+DISCORD_BOT_TOKEN=<bot token with access to the channel>
+DISCORD_CHANNEL_ID=<channel id to watch>
 
-# Optional overrides
-VITE_DISCORD_WIDGET_BASE=https://e.widgetbot.io/channels
-VITE_DISCORD_WIDGET_THEME=dark
+# Optional
+DISCORD_GUILD_ID=<guild id used to sanity-check the channel>
+DISCORD_POLL_INTERVAL_MS=15000   # how often to poll the channel (default 15s)
+DISCORD_MAX_MESSAGES=50          # how many recent messages to keep in memory (max 100)
 ```
 
-Restart the Vite dev server after editing the variables so the client receives the updated values.
+Invite the bot to your server with the `Read Messages/View Channel` and `Read Message History` permissions so the sync can succeed.

--- a/discordWatcher.js
+++ b/discordWatcher.js
@@ -1,0 +1,300 @@
+/* eslint-env node */
+import process from 'process';
+
+const DISCORD_API_BASE = 'https://discord.com/api/v10';
+
+class DiscordWatcherError extends Error {
+    constructor(message, { retryAfter, status, fatal } = {}) {
+        super(message);
+        this.name = 'DiscordWatcherError';
+        this.retryAfter = typeof retryAfter === 'number' && Number.isFinite(retryAfter) ? retryAfter : null;
+        this.status = status ?? null;
+        this.fatal = !!fatal;
+    }
+}
+
+function toNumber(value, fallback) {
+    const num = Number(value);
+    return Number.isFinite(num) ? num : fallback;
+}
+
+function buildAvatarUrl(author) {
+    if (!author || !author.id) return null;
+    const hash = author.avatar;
+    if (hash) {
+        const isGif = typeof hash === 'string' && hash.startsWith('a_');
+        const ext = isGif ? 'gif' : 'png';
+        return `https://cdn.discordapp.com/avatars/${author.id}/${hash}.${ext}?size=128`;
+    }
+    let fallbackIndex = 0;
+    if (author.discriminator && author.discriminator !== '0') {
+        fallbackIndex = Number(author.discriminator) % 6;
+    } else if (author.id) {
+        try {
+            fallbackIndex = Number(BigInt(author.id) % 6n);
+        } catch {
+            fallbackIndex = 0;
+        }
+    }
+    return `https://cdn.discordapp.com/embed/avatars/${fallbackIndex}.png`;
+}
+
+function replaceMentions(content, raw) {
+    if (typeof content !== 'string' || !content) return '';
+    let text = content;
+
+    if (Array.isArray(raw?.mentions)) {
+        for (const mention of raw.mentions) {
+            if (!mention?.id) continue;
+            const name = mention.global_name || mention.username || mention.id;
+            const pattern = new RegExp(`<@!?${mention.id}>`, 'g');
+            text = text.replace(pattern, `@${name}`);
+        }
+    }
+
+    if (Array.isArray(raw?.mention_channels)) {
+        for (const channel of raw.mention_channels) {
+            if (!channel?.id) continue;
+            const label = channel.name ? `#${channel.name}` : `#${channel.id}`;
+            const pattern = new RegExp(`<#${channel.id}>`, 'g');
+            text = text.replace(pattern, label);
+        }
+    }
+
+    return text;
+}
+
+function normalizeMessage(raw, channel) {
+    if (!raw || typeof raw !== 'object') return null;
+    const author = raw.author || {};
+    const displayName = raw.member?.nick || author.global_name || author.username || 'Unknown';
+    const attachments = Array.isArray(raw.attachments)
+        ? raw.attachments.map((att) => ({
+            id: att.id,
+            url: att.url,
+            proxyUrl: att.proxy_url ?? null,
+            name: att.filename || att.id,
+            contentType: att.content_type ?? null,
+            size: att.size ?? null,
+        }))
+        : [];
+    const createdAt = raw.timestamp || null;
+    const editedAt = raw.edited_timestamp || null;
+    const guildId = raw.guild_id || channel?.guildId || null;
+
+    return {
+        id: raw.id,
+        channelId: raw.channel_id || channel?.id || null,
+        guildId,
+        author: {
+            id: author.id || null,
+            username: author.username || null,
+            globalName: author.global_name || null,
+            discriminator: author.discriminator || null,
+            bot: !!author.bot,
+            displayName,
+            avatarUrl: buildAvatarUrl(author),
+        },
+        content: replaceMentions(raw.content || '', raw),
+        rawContent: raw.content || '',
+        createdAt,
+        editedAt,
+        attachments,
+        jumpLink: guildId && raw.channel_id && raw.id
+            ? `https://discord.com/channels/${guildId}/${raw.channel_id}/${raw.id}`
+            : null,
+    };
+}
+
+async function discordRequest(path, token, { signal } = {}) {
+    if (!token) throw new DiscordWatcherError('Missing Discord bot token', { fatal: true });
+    const url = `${DISCORD_API_BASE}${path}`;
+    const res = await fetch(url, {
+        method: 'GET',
+        headers: {
+            Authorization: `Bot ${token}`,
+            'User-Agent': 'jack-endex/discord-watcher (+https://example.com)',
+            Accept: 'application/json',
+        },
+        signal,
+    });
+
+    if (res.status === 429) {
+        let retryAfter = 1000;
+        try {
+            const body = await res.json();
+            if (body && typeof body.retry_after === 'number') {
+                retryAfter = Math.max(1000, Math.ceil(body.retry_after * 1000));
+            }
+        } catch {
+            // ignore
+        }
+        throw new DiscordWatcherError('Rate limited by Discord (429).', { retryAfter, status: 429 });
+    }
+    if (res.status === 401) {
+        throw new DiscordWatcherError('Unauthorized: check DISCORD_BOT_TOKEN.', { status: 401, fatal: true });
+    }
+    if (res.status === 403) {
+        throw new DiscordWatcherError('Forbidden: bot lacks access to the channel.', { status: 403 });
+    }
+    if (!res.ok) {
+        let message = `Discord API error ${res.status}`;
+        try {
+            const text = await res.text();
+            if (text) message += `: ${text.slice(0, 200)}`;
+        } catch {
+            // ignore
+        }
+        throw new DiscordWatcherError(message, { status: res.status });
+    }
+    return res.json();
+}
+
+export function createDiscordWatcher({
+    token,
+    guildId,
+    channelId,
+    pollIntervalMs = 15_000,
+    maxMessages = 50,
+} = {}) {
+    const normalizedPoll = Math.max(5_000, Math.min(120_000, toNumber(pollIntervalMs, 15_000)));
+    const limit = Math.max(1, Math.min(100, Math.floor(toNumber(maxMessages, 50))));
+    const enabled = Boolean(token && channelId);
+
+    const state = {
+        enabled,
+        phase: enabled ? 'idle' : 'disabled',
+        error: null,
+        lastErrorAt: null,
+        lastAttemptAt: null,
+        lastSyncAt: null,
+        readyAt: null,
+        channel: null,
+        pollIntervalMs: normalizedPoll,
+    };
+
+    const messages = [];
+    let started = false;
+    let timer = null;
+    let inFlight = false;
+    let stopped = false;
+
+    function setPhase(phase) {
+        state.phase = phase;
+        if (phase === 'ready' || phase === 'connecting') {
+            state.error = null;
+        }
+    }
+
+    function setError(message) {
+        state.phase = 'error';
+        state.error = message;
+        state.lastErrorAt = new Date().toISOString();
+    }
+
+    function scheduleNext(delayMs = state.pollIntervalMs) {
+        if (stopped) return;
+        clearTimeout(timer);
+        timer = setTimeout(async () => {
+            const nextDelay = await syncOnce();
+            scheduleNext(nextDelay);
+        }, Math.max(0, delayMs));
+    }
+
+    async function ensureChannelInfo() {
+        if (state.channel) return;
+        const data = await discordRequest(`/channels/${channelId}`, token);
+        if (guildId && data.guild_id && data.guild_id !== guildId) {
+            throw new DiscordWatcherError('Configured guild does not match channel guild.', { fatal: true });
+        }
+        state.channel = {
+            id: data.id,
+            name: data.name || data.id,
+            topic: data.topic || null,
+            guildId: data.guild_id || guildId || null,
+            url: data.guild_id ? `https://discord.com/channels/${data.guild_id}/${data.id}` : null,
+        };
+        if (!state.readyAt) state.readyAt = new Date().toISOString();
+    }
+
+    async function syncOnce() {
+        if (!enabled || stopped) return state.pollIntervalMs;
+        if (inFlight) return state.pollIntervalMs;
+        inFlight = true;
+        state.lastAttemptAt = new Date().toISOString();
+        try {
+            setPhase(state.channel ? 'ready' : 'connecting');
+            await ensureChannelInfo();
+            const raw = await discordRequest(`/channels/${channelId}/messages?limit=${limit}`, token);
+            const normalized = Array.isArray(raw)
+                ? raw
+                    .map((entry) => normalizeMessage(entry, state.channel))
+                    .filter(Boolean)
+                    .sort((a, b) => {
+                        const aTime = Date.parse(a.createdAt || '') || 0;
+                        const bTime = Date.parse(b.createdAt || '') || 0;
+                        return aTime - bTime;
+                    })
+                : [];
+            messages.splice(0, messages.length, ...normalized.slice(-limit));
+            state.lastSyncAt = new Date().toISOString();
+            if (!state.readyAt) state.readyAt = state.lastSyncAt;
+            setPhase('ready');
+            return state.pollIntervalMs;
+        } catch (err) {
+            const message = err instanceof Error ? err.message : 'Failed to sync Discord channel.';
+            setError(message);
+            const retry = err instanceof DiscordWatcherError && err.retryAfter
+                ? err.retryAfter
+                : Math.min(state.pollIntervalMs * 2, 120_000);
+            return retry;
+        } finally {
+            inFlight = false;
+        }
+    }
+
+    function start() {
+        if (started || !enabled) {
+            started = true;
+            return;
+        }
+        started = true;
+        stopped = false;
+        setPhase('connecting');
+        scheduleNext(0);
+    }
+
+    function stop() {
+        stopped = true;
+        clearTimeout(timer);
+        timer = null;
+    }
+
+    function getMessages() {
+        return messages.map((msg) => ({ ...msg }));
+    }
+
+    function getStatus() {
+        return { ...state, channel: state.channel ? { ...state.channel } : null };
+    }
+
+    return {
+        enabled,
+        start,
+        stop,
+        getMessages,
+        getStatus,
+    };
+}
+
+export function createWatcherFromEnv(env = process.env) {
+    return createDiscordWatcher({
+        token: env.DISCORD_BOT_TOKEN || env.BOT_TOKEN,
+        guildId: env.DISCORD_GUILD_ID || env.DISCORD_SERVER_ID,
+        channelId: env.DISCORD_CHANNEL_ID,
+        pollIntervalMs: env.DISCORD_POLL_INTERVAL_MS,
+        maxMessages: env.DISCORD_MAX_MESSAGES,
+    });
+}
+
+export { DiscordWatcherError };

--- a/web/src/api.js
+++ b/web/src/api.js
@@ -451,6 +451,10 @@ export const Personas = {
     get: (slug) => api(`/api/personas/${encodeURIComponent(slug)}`, { cache: 5000 }),
 };
 
+export const StoryLogs = {
+    fetch: () => api('/api/story-log'),
+};
+
 // ---------------- Helper: SSE (Server-Sent Events) ----------------
 // If you later expose real-time updates from the server, you can wire them here.
 /*

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -613,18 +613,126 @@ p  { margin: 0 0 .75rem; color: var(--text); }
     gap: 16px;
 }
 
-.story-logs__embed {
-    border: 1px solid var(--border);
-    border-radius: var(--radius);
-    overflow: hidden;
-    background: #0b0d17;
+.story-logs__actions {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    justify-content: flex-end;
+    flex-wrap: wrap;
 }
 
-.story-logs__embed iframe {
-    display: block;
+.story-logs__status {
+    display: flex;
+    gap: 12px;
+    align-items: center;
+    flex-wrap: wrap;
+    font-size: 0.85rem;
+}
+
+.story-logs__status-name {
+    font-weight: 600;
+}
+
+.story-logs__alert {
+    padding: 12px 14px;
+    border-radius: var(--radius-sm);
+    border: 1px solid color-mix(in srgb, var(--danger) 35%, transparent);
+    background: color-mix(in srgb, var(--danger) 12%, transparent);
+}
+
+.story-logs__body {
+    display: grid;
+    gap: 12px;
+}
+
+.story-logs__topic {
+    margin: 0;
+    font-size: 0.85rem;
+    white-space: pre-wrap;
+}
+
+.story-logs__messages {
+    display: grid;
+    gap: 16px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 16px;
+    background: color-mix(in srgb, var(--surface) 92%, transparent);
+    max-height: clamp(420px, 70vh, 760px);
+    overflow-y: auto;
+}
+
+.story-logs__message {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 12px;
+}
+
+.story-logs__avatar {
+    width: 44px;
+    height: 44px;
+    border-radius: 50%;
+    overflow: hidden;
+    background: color-mix(in srgb, var(--surface-2) 85%, transparent);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 600;
+}
+
+.story-logs__avatar img {
     width: 100%;
-    height: clamp(420px, 70vh, 760px);
-    border: 0;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+}
+
+.story-logs__message-body {
+    display: grid;
+    gap: 8px;
+}
+
+.story-logs__message-header {
+    display: flex;
+    gap: 8px;
+    align-items: baseline;
+    flex-wrap: wrap;
+}
+
+.story-logs__author {
+    font-weight: 600;
+}
+
+.story-logs__timestamp {
+    font-size: 0.75rem;
+    color: var(--muted);
+}
+
+.story-logs__message-text {
+    margin: 0;
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
+.story-logs__attachments {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+}
+
+.story-logs__attachments li {
+    margin: 0;
+}
+
+.story-logs__attachments a {
+    font-size: 0.85rem;
+}
+
+.story-logs__message-footer {
+    font-size: 0.85rem;
 }
 
 .story-logs__empty {


### PR DESCRIPTION
## Summary
- add a backend Discord watcher that polls the configured channel and exposes `/api/story-log`
- update the Story Logs tab to consume the server endpoint and render Discord messages with metadata
- document the new server environment variables required for the bot

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d031661c7483319bc3ca54588f345d