### PR TITLE
Fix Vite proxy target to local API

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -10,7 +10,7 @@ export default defineConfig({
         proxy: {
             // Frontend calls `/api/...` and Vite forwards to your Node API
             '/api': {
-                target: 'http://192.168.50.181:3000', // <- your API port
+                target: 'http://127.0.0.1:3000', // <- your API port
                 changeOrigin: true,
                 secure: false,
                 ws: true,


### PR DESCRIPTION
## Summary
- update the Vite dev server proxy to target the local API instead of a LAN IP so API requests succeed during development

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d03965ac588331bbc20d9fca528eb3