### PR TITLE
Enable dynamic world skill management and realtime sync

### DIFF
--- a/web/src/api.js
+++ b/web/src/api.js
@@ -403,6 +403,15 @@ export const Games = {
     joinByCode: (code) => api(`/api/games/join/${encodeURIComponent(code)}`, { method: 'POST' }),
     setPerms: (id, perms) => api(`/api/games/${encodeURIComponent(id)}/permissions`, { method: 'PUT', body: perms }),
     saveCharacter: (id, character) => api(`/api/games/${encodeURIComponent(id)}/character`, { method: 'PUT', body: { character } }),
+    addWorldSkill: (id, skill) =>
+        api(`/api/games/${encodeURIComponent(id)}/world-skills`, { method: 'POST', body: { skill } }),
+    updateWorldSkill: (id, skillId, skill) =>
+        api(`/api/games/${encodeURIComponent(id)}/world-skills/${encodeURIComponent(skillId)}`, {
+            method: 'PUT',
+            body: { skill },
+        }),
+    deleteWorldSkill: (id, skillId) =>
+        api(`/api/games/${encodeURIComponent(id)}/world-skills/${encodeURIComponent(skillId)}`, { method: 'DELETE' }),
     addCustomItem: (id, item) => api(`/api/games/${encodeURIComponent(id)}/items/custom`, { method: 'POST', body: { item } }),
     updateCustomItem: (id, itemId, item) => api(`/api/games/${encodeURIComponent(id)}/items/custom/${encodeURIComponent(itemId)}`, { method: 'PUT', body: { item } }),
     deleteCustomItem: (id, itemId) => api(`/api/games/${encodeURIComponent(id)}/items/custom/${encodeURIComponent(itemId)}`, { method: 'DELETE' }),


### PR DESCRIPTION
## Summary
- add normalized world skill definitions on the server, wire CRUD routes to broadcast via the new game websocket channel, and replace direct DB writes with a persistGame helper
- subscribe the client realtime hook to the game channel, auto-refresh game data, and keep the SPA URL in sync with /game/:id plus tab/player parameters
- update world skill UIs and the character creation wizard to use dynamic skill lists, and let DMs give custom items directly to the selected player inventory

## Testing
- npm run lint


------
https://chatgpt.com/codex/tasks/task_e_68d06fca1a5083318e975b5b81922898