### PR TITLE
Allow versioned Discord webhook URLs

### DIFF
--- a/server.js
+++ b/server.js
@@ -1718,7 +1718,9 @@ function readWebhookUrl(value) {
         const url = new URL(trimmed);
         const host = url.host.toLowerCase();
         if (!host.endsWith('discord.com') && !host.endsWith('discordapp.com')) return '';
-        if (!url.pathname.startsWith('/api/webhooks/')) return '';
+        const path = url.pathname;
+        const webhookPattern = /^\/api(?:\/v\d+)?\/webhooks\//;
+        if (!webhookPattern.test(path)) return '';
         return url.toString();
     } catch {
         return '';


### PR DESCRIPTION
## Summary
- allow Discord webhook URLs that include an API version segment so campaign settings accept /api/v10 links

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d088f6841c8331a0d571f120a6e869