### PR TITLE
Add DM media broadcast and alert popups

### DIFF
--- a/web/src/style.css
+++ b/web/src/style.css
@@ -123,6 +123,10 @@ p  { margin: 0 0 .75rem; color: var(--text); }
     align-items: center;
 }
 
+.row.wrap {
+    flex-wrap: wrap;
+}
+
 .col {
     display: flex;
     flex-direction: column;
@@ -1310,6 +1314,34 @@ p  { margin: 0 0 .75rem; color: var(--text); }
     gap: 20px;
 }
 
+.dm-broadcast__form {
+    display: grid;
+    gap: 8px;
+}
+
+.dm-broadcast__form .row.wrap {
+    align-items: stretch;
+}
+
+.dm-broadcast__form input {
+    flex: 1 1 240px;
+    min-width: 180px;
+}
+
+.dm-broadcast__now-playing {
+    color: var(--muted);
+    word-break: break-word;
+}
+
+.dm-broadcast__now-playing a {
+    color: var(--brand);
+    text-decoration: none;
+}
+
+.dm-broadcast__now-playing a:hover {
+    text-decoration: underline;
+}
+
 .overview-metrics {
     display: grid;
     gap: 12px;
@@ -1409,6 +1441,122 @@ p  { margin: 0 0 .75rem; color: var(--text); }
 
 .resource-chip strong {
     font-size: 1.3rem;
+}
+
+.shared-media {
+    position: fixed;
+    bottom: 24px;
+    right: 24px;
+    width: min(420px, calc(100vw - 32px));
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow-md);
+    z-index: 1200;
+}
+
+.shared-media__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 8px;
+    padding: 12px 16px;
+    border-bottom: 1px solid var(--border);
+}
+
+.shared-media__actions {
+    display: flex;
+    gap: 8px;
+}
+
+.shared-media__body {
+    display: grid;
+    gap: 12px;
+    padding: 12px 16px 16px;
+}
+
+.shared-media__player {
+    aspect-ratio: 16 / 9;
+    background: #000;
+    border-radius: var(--radius-sm);
+    overflow: hidden;
+}
+
+.shared-media__player iframe {
+    width: 100%;
+    height: 100%;
+    border: 0;
+}
+
+.shared-media__footer {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 12px;
+}
+
+.shared-media__links a {
+    color: var(--brand);
+    font-weight: 600;
+    text-decoration: none;
+}
+
+.shared-media__links a:hover {
+    text-decoration: underline;
+}
+
+.shared-media.is-collapsed .shared-media__body {
+    display: none;
+}
+
+.shared-media.is-collapsed .shared-media__header {
+    border-bottom: none;
+}
+
+.alert-overlay {
+    position: fixed;
+    top: 24px;
+    right: 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    width: min(320px, calc(100vw - 32px));
+    z-index: 1250;
+}
+
+.alert-toast {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow-md);
+    padding: 12px 16px;
+    display: grid;
+    gap: 8px;
+}
+
+.alert-toast__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 8px;
+}
+
+.alert-toast p {
+    margin: 0;
+}
+
+@media (max-width: 720px) {
+    .shared-media {
+        left: 16px;
+        right: 16px;
+        width: auto;
+    }
+
+    .alert-overlay {
+        left: 16px;
+        right: 16px;
+        width: auto;
+    }
 }
 
 @media (max-width: 640px) {


### PR DESCRIPTION
## Summary
- add backend support for DM-triggered YouTube playback state and alert broadcasts
- extend realtime client state to sync shared media, clear errors, and track dismissible DM alerts
- provide DM controls plus shared video/alert overlays with supporting styles so players can mute or dismiss as needed

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d086c55a388331acb67cd1f3d3a82c