### PR TITLE
Add world skill filtering and DM revoke control

### DIFF
--- a/web/src/style.css
+++ b/web/src/style.css
@@ -1575,6 +1575,11 @@ label {
 
 .world-skill-manager { display: grid; gap: 16px; }
 .world-skill-manager__header { display: flex; justify-content: space-between; align-items: center; gap: 12px; flex-wrap: wrap; }
+.world-skill-manager__header-actions { display: grid; gap: 8px; justify-items: end; align-items: center; }
+.world-skill-manager__tools { display: flex; gap: 8px; flex-wrap: wrap; justify-content: flex-end; }
+.world-skill-manager__search { min-width: 200px; }
+.world-skill-manager__sort { display: grid; gap: 4px; text-align: right; font-weight: 600; color: var(--muted); }
+.world-skill-manager__sort select { min-width: 170px; }
 .world-skill-manager__status { color: var(--brand-600); font-weight: 600; letter-spacing: 0.04em; }
 .world-skill-grid { display: grid; gap: 14px; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); }
 .world-skill-card { position: relative; border: 1px solid var(--border); border-radius: var(--radius); padding: 16px; background: var(--surface-2); display: grid; gap: 12px; min-height: 180px; transition: border-color var(--trans-fast), box-shadow var(--trans-fast), transform var(--trans-fast); }


### PR DESCRIPTION
## Summary
- add search and sort controls to the world skill manager so DMs can quickly find entries
- surface empty states for filtered results and keep the active edit visible while filtering
- allow DMs to reset a player's world skill ranks with a dedicated "Take away" action and supporting styles

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d08d2f62888331830bf4a7cab23645