### PR TITLE
Add real-time battle map support

### DIFF
--- a/server.js
+++ b/server.js
@@ -27,6 +27,13 @@ const PERSONA_REQUEST_TIMEOUT_MS = 120_000;
 const TRADE_TIMEOUT_MS = 180_000;
 const YOUTUBE_ID_REGEX = /^[A-Za-z0-9_-]{11}$/;
 const MAX_ALERT_LENGTH = 500;
+const HEX_COLOR_REGEX = /^#(?:[0-9a-f]{3}|[0-9a-f]{6})$/i;
+const MAX_MAP_STROKES = 800;
+const MAX_MAP_POINTS_PER_STROKE = 600;
+const DEFAULT_STROKE_COLOR = '#f97316';
+const DEFAULT_PLAYER_TOKEN_COLOR = '#38bdf8';
+const DEFAULT_DEMON_TOKEN_COLOR = '#f97316';
+const DEFAULT_CUSTOM_TOKEN_COLOR = '#a855f7';
 
 function parseYouTubeTimecode(raw) {
     if (typeof raw !== 'string') return 0;
@@ -141,6 +148,247 @@ function presentMediaState(media) {
 function sanitizeAlertMessage(value) {
     if (typeof value !== 'string') return '';
     return value.trim().slice(0, MAX_ALERT_LENGTH);
+}
+
+function clamp01(value) {
+    const num = Number(value);
+    if (!Number.isFinite(num)) return 0;
+    if (num <= 0) return 0;
+    if (num >= 1) return 1;
+    return num;
+}
+
+function sanitizeColor(value, fallback) {
+    if (typeof value !== 'string') return fallback;
+    const trimmed = value.trim();
+    if (!trimmed) return fallback;
+    return HEX_COLOR_REGEX.test(trimmed) ? trimmed.toLowerCase() : fallback;
+}
+
+function normalizeMapPoint(point) {
+    if (!point) return null;
+    let x;
+    let y;
+    if (Array.isArray(point)) {
+        [x, y] = point;
+    } else if (typeof point === 'object') {
+        x = point.x;
+        y = point.y;
+    }
+    if (!Number.isFinite(Number(x)) || !Number.isFinite(Number(y))) return null;
+    return { x: clamp01(x), y: clamp01(y) };
+}
+
+function normalizeMapStroke(entry, extras = {}) {
+    if (!entry || typeof entry !== 'object') return null;
+    const id = typeof entry.id === 'string' && entry.id.trim() ? entry.id.trim() : uuid();
+    const widthRaw = Number(entry.size);
+    const size = Number.isFinite(widthRaw) ? Math.min(32, Math.max(1, widthRaw)) : 3;
+    const color = sanitizeColor(entry.color, DEFAULT_STROKE_COLOR);
+    const points = [];
+    const sourcePoints = Array.isArray(entry.points) ? entry.points : [];
+    for (const point of sourcePoints) {
+        const normalized = normalizeMapPoint(point);
+        if (!normalized) continue;
+        points.push(normalized);
+        if (points.length >= MAX_MAP_POINTS_PER_STROKE) break;
+    }
+    if (points.length < 2) return null;
+    const createdAt = typeof entry.createdAt === 'string' ? entry.createdAt : new Date().toISOString();
+    const createdBy = typeof entry.createdBy === 'string' ? entry.createdBy : extras.createdBy || null;
+    return { id, size, color, points, createdAt, createdBy };
+}
+
+function buildPlayerTooltip(player) {
+    if (!player || typeof player !== 'object') return '';
+    const lines = [];
+    const character = player.character || {};
+    if (character?.profile?.class) lines.push(character.profile.class);
+    const levelRaw = Number(character?.resources?.level);
+    if (Number.isFinite(levelRaw) && levelRaw > 0) lines.push(`Level ${levelRaw}`);
+    const hpRaw = Number(character?.resources?.hp);
+    const maxHpRaw = Number(character?.resources?.maxHP);
+    if (Number.isFinite(hpRaw) && Number.isFinite(maxHpRaw)) {
+        lines.push(`HP ${hpRaw}/${maxHpRaw}`);
+    }
+    return lines.join(' · ');
+}
+
+function buildDemonTooltip(demon) {
+    if (!demon || typeof demon !== 'object') return '';
+    const lines = [];
+    if (demon.arcana) lines.push(demon.arcana);
+    if (demon.alignment) lines.push(demon.alignment);
+    const levelRaw = Number(demon.level);
+    if (Number.isFinite(levelRaw) && levelRaw > 0) lines.push(`Level ${levelRaw}`);
+    return lines.join(' · ');
+}
+
+function normalizeMapToken(entry, game) {
+    if (!entry || typeof entry !== 'object') return null;
+    const kindRaw = typeof entry.kind === 'string' ? entry.kind.trim().toLowerCase() : 'custom';
+    const allowedKinds = new Set(['player', 'demon', 'custom']);
+    const kind = allowedKinds.has(kindRaw) ? kindRaw : 'custom';
+    let refId = typeof entry.refId === 'string' ? entry.refId : null;
+    const id = typeof entry.id === 'string' && entry.id.trim() ? entry.id.trim() : uuid();
+    let label = sanitizeText(entry.label).trim();
+    let tooltip = sanitizeText(entry.tooltip).trim();
+    const createdAt = typeof entry.createdAt === 'string' ? entry.createdAt : new Date().toISOString();
+    const updatedAt = typeof entry.updatedAt === 'string' ? entry.updatedAt : createdAt;
+    let showTooltip = entry.showTooltip === undefined ? true : !!entry.showTooltip;
+    let color = sanitizeColor(entry.color, DEFAULT_CUSTOM_TOKEN_COLOR);
+    let ownerId = typeof entry.ownerId === 'string' ? entry.ownerId : null;
+
+    if (kind === 'player') {
+        const player = findPlayer(game, refId);
+        if (!player) return null;
+        refId = player.userId;
+        ownerId = player.userId;
+        if (!label) {
+            label = describePlayerLabel(player, { username: player.username });
+        }
+        if (!tooltip) tooltip = buildPlayerTooltip(player);
+        color = sanitizeColor(entry.color, DEFAULT_PLAYER_TOKEN_COLOR);
+    } else if (kind === 'demon') {
+        const demon = Array.isArray(game.demons) ? game.demons.find((d) => d && d.id === refId) : null;
+        if (!demon) return null;
+        refId = demon.id;
+        if (!label) label = demon.name || 'Demon';
+        if (!tooltip) tooltip = buildDemonTooltip(demon);
+        color = sanitizeColor(entry.color, DEFAULT_DEMON_TOKEN_COLOR);
+    } else {
+        if (!label) label = 'Marker';
+        if (entry.showTooltip === undefined) showTooltip = !!tooltip;
+    }
+
+    const x = clamp01(entry.x);
+    const y = clamp01(entry.y);
+
+    return { id, kind, refId, label, tooltip, showTooltip, color, x, y, createdAt, updatedAt, ownerId };
+}
+
+function presentMapStroke(stroke) {
+    if (!stroke || typeof stroke !== 'object') return null;
+    const points = Array.isArray(stroke.points)
+        ? stroke.points
+              .map((point) => normalizeMapPoint(point))
+              .filter(Boolean)
+        : [];
+    if (points.length < 2) return null;
+    return {
+        id: stroke.id,
+        size: Number(stroke.size) || 3,
+        color: sanitizeColor(stroke.color, DEFAULT_STROKE_COLOR),
+        points,
+        createdAt: typeof stroke.createdAt === 'string' ? stroke.createdAt : null,
+        createdBy: typeof stroke.createdBy === 'string' ? stroke.createdBy : null,
+    };
+}
+
+function presentMapToken(token) {
+    if (!token || typeof token !== 'object') return null;
+    return {
+        id: token.id,
+        kind: token.kind,
+        refId: token.refId || null,
+        label: token.label || '',
+        tooltip: token.tooltip || '',
+        showTooltip: !!token.showTooltip,
+        color: sanitizeColor(token.color, DEFAULT_CUSTOM_TOKEN_COLOR),
+        x: clamp01(token.x),
+        y: clamp01(token.y),
+        ownerId: typeof token.ownerId === 'string' ? token.ownerId : null,
+        updatedAt: typeof token.updatedAt === 'string' ? token.updatedAt : null,
+        createdAt: typeof token.createdAt === 'string' ? token.createdAt : null,
+    };
+}
+
+function ensureMapState(game) {
+    if (!game || typeof game !== 'object') {
+        return {
+            strokes: [],
+            tokens: [],
+            settings: { allowPlayerDrawing: false, allowPlayerTokenMoves: false },
+            paused: false,
+            updatedAt: new Date().toISOString(),
+        };
+    }
+    const raw = game.map && typeof game.map === 'object' ? game.map : {};
+    const settingsRaw = raw.settings && typeof raw.settings === 'object' ? raw.settings : {};
+    let strokes = Array.isArray(raw.strokes)
+        ? raw.strokes.map((stroke) => normalizeMapStroke(stroke)).filter(Boolean)
+        : [];
+    if (strokes.length > MAX_MAP_STROKES) {
+        strokes = strokes.slice(-MAX_MAP_STROKES);
+    }
+    const tokens = Array.isArray(raw.tokens)
+        ? raw.tokens.map((token) => normalizeMapToken(token, game)).filter(Boolean)
+        : [];
+    const updatedAt = typeof raw.updatedAt === 'string' ? raw.updatedAt : new Date().toISOString();
+    const mapState = {
+        strokes,
+        tokens,
+        settings: {
+            allowPlayerDrawing: !!settingsRaw.allowPlayerDrawing,
+            allowPlayerTokenMoves: !!settingsRaw.allowPlayerTokenMoves,
+        },
+        paused: !!raw.paused,
+        updatedAt,
+    };
+    game.map = mapState;
+    return mapState;
+}
+
+function presentMapState(map) {
+    if (!map || typeof map !== 'object') {
+        return {
+            strokes: [],
+            tokens: [],
+            settings: { allowPlayerDrawing: false, allowPlayerTokenMoves: false },
+            paused: false,
+            updatedAt: null,
+        };
+    }
+    const strokes = Array.isArray(map.strokes)
+        ? map.strokes.map((stroke) => presentMapStroke(stroke)).filter(Boolean)
+        : [];
+    const tokens = Array.isArray(map.tokens)
+        ? map.tokens.map((token) => presentMapToken(token)).filter(Boolean)
+        : [];
+    return {
+        strokes,
+        tokens,
+        settings: {
+            allowPlayerDrawing: !!map.settings?.allowPlayerDrawing,
+            allowPlayerTokenMoves: !!map.settings?.allowPlayerTokenMoves,
+        },
+        paused: !!map.paused,
+        updatedAt: typeof map.updatedAt === 'string' ? map.updatedAt : null,
+    };
+}
+
+function canDrawOnMap(game, userId) {
+    if (!userId) return false;
+    if (isDM(game, userId)) return true;
+    if (!isMember(game, userId)) return false;
+    const map = ensureMapState(game);
+    if (map.paused) return false;
+    return !!map.settings?.allowPlayerDrawing;
+}
+
+function canMoveMapToken(game, userId, token) {
+    if (!userId || !token) return false;
+    if (isDM(game, userId)) return true;
+    if (!isMember(game, userId)) return false;
+    const map = ensureMapState(game);
+    if (map.paused) return false;
+    if (!map.settings?.allowPlayerTokenMoves) return false;
+    return !!token.ownerId && token.ownerId === userId;
+}
+
+function findMapToken(map, tokenId) {
+    if (!map || !Array.isArray(map.tokens)) return null;
+    return map.tokens.find((token) => token && token.id === tokenId) || null;
 }
 
 /**
@@ -258,6 +506,7 @@ function ensureGameShape(game) {
     game.story = ensureStoryConfig(game);
     game.worldSkills = ensureWorldSkills(game);
     game.media = ensureMediaState(game);
+    game.map = ensureMapState(game);
     return game;
 }
 
@@ -280,6 +529,7 @@ function presentGame(game, { includeSecrets = false } = {}) {
         story: presentStoryConfig(story, { includeSecrets }),
         worldSkills,
         media: presentMediaState(normalized.media),
+        map: presentMapState(normalized.map),
     };
 }
 
@@ -2225,8 +2475,16 @@ app.post('/api/games', requireAuth, async (req, res) => {
             scribeIds: [],
             pollIntervalMs: 15_000,
         },
+        map: {
+            strokes: [],
+            tokens: [],
+            settings: { allowPlayerDrawing: false, allowPlayerTokenMoves: false },
+            paused: false,
+            updatedAt: new Date().toISOString(),
+        },
     };
     ensureWorldSkills(game);
+    ensureMapState(game);
     db.games.push(game);
     await writeDB(db);
     res.json(presentGame(game, { includeSecrets: true }));
@@ -2368,6 +2626,294 @@ app.put('/api/games/:id/character', requireAuth, async (req, res) => {
     }
 
     await persistGame(db, game);
+    res.json({ ok: true });
+});
+
+app.put('/api/games/:id/map/settings', requireAuth, async (req, res) => {
+    const { id } = req.params || {};
+    const db = await readDB();
+    const game = getGame(db, id);
+    if (!game || !isMember(game, req.session.userId)) {
+        return res.status(404).json({ error: 'not_found' });
+    }
+    if (!isDM(game, req.session.userId)) {
+        return res.status(403).json({ error: 'forbidden' });
+    }
+
+    const map = ensureMapState(game);
+    const payload = req.body || {};
+    let changed = false;
+
+    if (Object.prototype.hasOwnProperty.call(payload, 'allowPlayerDrawing')) {
+        const value = !!payload.allowPlayerDrawing;
+        if (map.settings.allowPlayerDrawing !== value) {
+            map.settings.allowPlayerDrawing = value;
+            changed = true;
+        }
+    }
+    if (Object.prototype.hasOwnProperty.call(payload, 'allowPlayerTokenMoves')) {
+        const value = !!payload.allowPlayerTokenMoves;
+        if (map.settings.allowPlayerTokenMoves !== value) {
+            map.settings.allowPlayerTokenMoves = value;
+            changed = true;
+        }
+    }
+    if (Object.prototype.hasOwnProperty.call(payload, 'paused')) {
+        const paused = !!payload.paused;
+        if (map.paused !== paused) {
+            map.paused = paused;
+            changed = true;
+        }
+    }
+
+    if (!changed) {
+        return res.json(presentMapState(map));
+    }
+
+    map.updatedAt = new Date().toISOString();
+    await persistGame(db, game, {
+        reason: 'map:settings',
+        actorId: req.session.userId,
+        broadcast: true,
+    });
+    res.json(presentMapState(map));
+});
+
+app.post('/api/games/:id/map/strokes', requireAuth, async (req, res) => {
+    const { id } = req.params || {};
+    const db = await readDB();
+    const game = getGame(db, id);
+    if (!game || !isMember(game, req.session.userId)) {
+        return res.status(404).json({ error: 'not_found' });
+    }
+
+    const map = ensureMapState(game);
+    if (!canDrawOnMap(game, req.session.userId)) {
+        return res.status(403).json({ error: 'forbidden' });
+    }
+
+    const payload = req.body?.stroke || req.body || {};
+    const stroke = normalizeMapStroke(payload, { createdBy: req.session.userId });
+    if (!stroke) {
+        return res.status(400).json({ error: 'invalid_stroke' });
+    }
+
+    const timestamp = new Date().toISOString();
+    stroke.createdAt = timestamp;
+    stroke.createdBy = stroke.createdBy || req.session.userId;
+    map.strokes.push(stroke);
+    if (map.strokes.length > MAX_MAP_STROKES) {
+        map.strokes = map.strokes.slice(-MAX_MAP_STROKES);
+    }
+    map.updatedAt = timestamp;
+
+    await persistGame(db, game, {
+        reason: 'map:stroke',
+        actorId: req.session.userId,
+        broadcast: !map.paused,
+    });
+
+    res.status(201).json(presentMapStroke(stroke));
+});
+
+app.delete('/api/games/:id/map/strokes/:strokeId', requireAuth, async (req, res) => {
+    const { id, strokeId } = req.params || {};
+    const db = await readDB();
+    const game = getGame(db, id);
+    if (!game || !isMember(game, req.session.userId)) {
+        return res.status(404).json({ error: 'not_found' });
+    }
+    if (!isDM(game, req.session.userId)) {
+        return res.status(403).json({ error: 'forbidden' });
+    }
+
+    const map = ensureMapState(game);
+    const before = map.strokes.length;
+    map.strokes = map.strokes.filter((stroke) => stroke && stroke.id !== strokeId);
+    if (map.strokes.length === before) {
+        return res.status(404).json({ error: 'stroke_not_found' });
+    }
+
+    map.updatedAt = new Date().toISOString();
+    await persistGame(db, game, {
+        reason: 'map:stroke:remove',
+        actorId: req.session.userId,
+        broadcast: !map.paused,
+    });
+    res.json({ ok: true });
+});
+
+app.post('/api/games/:id/map/strokes/clear', requireAuth, async (req, res) => {
+    const { id } = req.params || {};
+    const db = await readDB();
+    const game = getGame(db, id);
+    if (!game || !isMember(game, req.session.userId)) {
+        return res.status(404).json({ error: 'not_found' });
+    }
+    if (!isDM(game, req.session.userId)) {
+        return res.status(403).json({ error: 'forbidden' });
+    }
+
+    const map = ensureMapState(game);
+    map.strokes = [];
+    map.updatedAt = new Date().toISOString();
+
+    await persistGame(db, game, {
+        reason: 'map:stroke:clear',
+        actorId: req.session.userId,
+        broadcast: !map.paused,
+    });
+    res.json({ ok: true });
+});
+
+app.post('/api/games/:id/map/tokens', requireAuth, async (req, res) => {
+    const { id } = req.params || {};
+    const db = await readDB();
+    const game = getGame(db, id);
+    if (!game || !isMember(game, req.session.userId)) {
+        return res.status(404).json({ error: 'not_found' });
+    }
+    if (!isDM(game, req.session.userId)) {
+        return res.status(403).json({ error: 'forbidden' });
+    }
+
+    const map = ensureMapState(game);
+    const payload = req.body?.token || req.body || {};
+    const base = {
+        id: uuid(),
+        kind: typeof payload.kind === 'string' ? payload.kind : 'custom',
+        refId: typeof payload.refId === 'string' ? payload.refId : null,
+        label: payload.label,
+        tooltip: payload.tooltip,
+        color: payload.color,
+        showTooltip: payload.showTooltip,
+        x: Object.prototype.hasOwnProperty.call(payload, 'x') ? payload.x : 0.5,
+        y: Object.prototype.hasOwnProperty.call(payload, 'y') ? payload.y : 0.5,
+    };
+    const token = normalizeMapToken(base, game);
+    if (!token) {
+        return res.status(400).json({ error: 'invalid_token' });
+    }
+    const timestamp = new Date().toISOString();
+    token.createdAt = timestamp;
+    token.updatedAt = timestamp;
+
+    map.tokens.push(token);
+    map.updatedAt = timestamp;
+
+    await persistGame(db, game, {
+        reason: 'map:token:add',
+        actorId: req.session.userId,
+        broadcast: !map.paused,
+    });
+
+    res.status(201).json(presentMapToken(token));
+});
+
+app.put('/api/games/:id/map/tokens/:tokenId', requireAuth, async (req, res) => {
+    const { id, tokenId } = req.params || {};
+    const db = await readDB();
+    const game = getGame(db, id);
+    if (!game || !isMember(game, req.session.userId)) {
+        return res.status(404).json({ error: 'not_found' });
+    }
+
+    const map = ensureMapState(game);
+    const token = findMapToken(map, tokenId);
+    if (!token) {
+        return res.status(404).json({ error: 'token_not_found' });
+    }
+
+    const payload = req.body || {};
+    const isDMUser = isDM(game, req.session.userId);
+    let changed = false;
+
+    if (Object.prototype.hasOwnProperty.call(payload, 'x') || Object.prototype.hasOwnProperty.call(payload, 'y')) {
+        if (!canMoveMapToken(game, req.session.userId, token)) {
+            return res.status(403).json({ error: 'forbidden' });
+        }
+        if (Object.prototype.hasOwnProperty.call(payload, 'x')) {
+            token.x = clamp01(payload.x);
+        }
+        if (Object.prototype.hasOwnProperty.call(payload, 'y')) {
+            token.y = clamp01(payload.y);
+        }
+        changed = true;
+    }
+
+    if (Object.prototype.hasOwnProperty.call(payload, 'showTooltip')) {
+        if (!isDMUser) {
+            return res.status(403).json({ error: 'forbidden' });
+        }
+        token.showTooltip = !!payload.showTooltip;
+        changed = true;
+    }
+
+    if (Object.prototype.hasOwnProperty.call(payload, 'label')) {
+        if (!isDMUser) {
+            return res.status(403).json({ error: 'forbidden' });
+        }
+        token.label = sanitizeText(payload.label).trim() || token.label;
+        changed = true;
+    }
+
+    if (Object.prototype.hasOwnProperty.call(payload, 'tooltip')) {
+        if (!isDMUser) {
+            return res.status(403).json({ error: 'forbidden' });
+        }
+        token.tooltip = sanitizeText(payload.tooltip).trim();
+        changed = true;
+    }
+
+    if (Object.prototype.hasOwnProperty.call(payload, 'color')) {
+        if (!isDMUser) {
+            return res.status(403).json({ error: 'forbidden' });
+        }
+        token.color = sanitizeColor(payload.color, token.color);
+        changed = true;
+    }
+
+    if (!changed) {
+        return res.json(presentMapToken(token));
+    }
+
+    const timestamp = new Date().toISOString();
+    token.updatedAt = timestamp;
+    map.updatedAt = timestamp;
+
+    await persistGame(db, game, {
+        reason: 'map:token:update',
+        actorId: req.session.userId,
+        broadcast: !map.paused,
+    });
+
+    res.json(presentMapToken(token));
+});
+
+app.delete('/api/games/:id/map/tokens/:tokenId', requireAuth, async (req, res) => {
+    const { id, tokenId } = req.params || {};
+    const db = await readDB();
+    const game = getGame(db, id);
+    if (!game || !isMember(game, req.session.userId)) {
+        return res.status(404).json({ error: 'not_found' });
+    }
+    if (!isDM(game, req.session.userId)) {
+        return res.status(403).json({ error: 'forbidden' });
+    }
+
+    const map = ensureMapState(game);
+    const before = map.tokens.length;
+    map.tokens = map.tokens.filter((token) => token && token.id !== tokenId);
+    if (before === map.tokens.length) {
+        return res.status(404).json({ error: 'token_not_found' });
+    }
+
+    map.updatedAt = new Date().toISOString();
+    await persistGame(db, game, {
+        reason: 'map:token:remove',
+        actorId: req.session.userId,
+        broadcast: !map.paused,
+    });
     res.json({ ok: true });
 });
 

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -35,6 +35,11 @@ const DM_NAV = [
         description: "Monitor the party at a glance",
     },
     {
+        key: "map",
+        label: "Battle Map",
+        description: "Sketch encounters and track tokens",
+    },
+    {
         key: "sheet",
         label: "Character Sheets",
         description: "Review and update any adventurer",
@@ -86,6 +91,11 @@ const PLAYER_NAV = [
         key: "sheet",
         label: "My Character",
         description: "Update your stats and background",
+    },
+    {
+        key: "map",
+        label: "Battle Map",
+        description: "Follow encounters in real time",
     },
     {
         key: "party",
@@ -1881,6 +1891,8 @@ function GameView({
                         />
                     )}
 
+                    {tab === "map" && <MapTab game={game} me={me} />}
+
                     {tab === "items" && (
                         <ItemsTab
                             game={game}
@@ -1988,6 +2000,902 @@ function GameView({
                 <TradeOverlay game={game} me={me} realtime={realtime} />
             </div>
         </RealtimeContext.Provider>
+    );
+}
+
+const MAP_DEFAULT_SETTINGS = Object.freeze({
+    allowPlayerDrawing: false,
+    allowPlayerTokenMoves: false,
+});
+
+const MAP_BRUSH_COLORS = ['#f97316', '#38bdf8', '#a855f7', '#22c55e', '#f472b6'];
+const MAP_MAX_POINTS_PER_STROKE = 600;
+
+function mapClamp01(value) {
+    const num = Number(value);
+    if (!Number.isFinite(num)) return 0;
+    if (num <= 0) return 0;
+    if (num >= 1) return 1;
+    return num;
+}
+
+function normalizeClientMapPoint(point) {
+    if (!point) return null;
+    if (Array.isArray(point)) {
+        return { x: mapClamp01(point[0]), y: mapClamp01(point[1]) };
+    }
+    if (typeof point === 'object') {
+        return { x: mapClamp01(point.x), y: mapClamp01(point.y) };
+    }
+    return null;
+}
+
+function normalizeClientMapStroke(stroke) {
+    if (!stroke || typeof stroke !== 'object') return null;
+    const color = typeof stroke.color === 'string' && stroke.color ? stroke.color : MAP_BRUSH_COLORS[0];
+    const widthRaw = Number(stroke.size);
+    const size = Number.isFinite(widthRaw) ? Math.min(32, Math.max(1, widthRaw)) : 3;
+    const source = Array.isArray(stroke.points) ? stroke.points : [];
+    const points = [];
+    for (const point of source) {
+        const normalized = normalizeClientMapPoint(point);
+        if (!normalized) continue;
+        points.push(normalized);
+        if (points.length >= MAP_MAX_POINTS_PER_STROKE) break;
+    }
+    if (points.length < 2) return null;
+    return {
+        id: stroke.id || `stroke-${Math.random().toString(36).slice(2, 10)}`,
+        color,
+        size,
+        points,
+        createdAt: typeof stroke.createdAt === 'string' ? stroke.createdAt : null,
+    };
+}
+
+function normalizeClientMapToken(token) {
+    if (!token || typeof token !== 'object') return null;
+    const kind = typeof token.kind === 'string' ? token.kind : 'custom';
+    const labelRaw = typeof token.label === 'string' ? token.label : '';
+    const label = labelRaw.trim() || (kind === 'player' ? 'Player' : kind === 'demon' ? 'Demon' : 'Marker');
+    const tooltipRaw = typeof token.tooltip === 'string' ? token.tooltip : '';
+    const tooltipTrimmed = tooltipRaw.trim();
+    const tooltip = tooltipTrimmed || label;
+    const showTooltip = token.showTooltip !== false && !!tooltip;
+    let color = typeof token.color === 'string' && token.color ? token.color : '#a855f7';
+    if (!token.color) {
+        if (kind === 'player') color = '#38bdf8';
+        else if (kind === 'demon') color = '#f97316';
+    }
+    return {
+        id: token.id || `token-${Math.random().toString(36).slice(2, 10)}`,
+        kind,
+        refId: typeof token.refId === 'string' ? token.refId : null,
+        label,
+        tooltip,
+        rawTooltip: tooltipTrimmed,
+        showTooltip,
+        color,
+        x: mapClamp01(token.x),
+        y: mapClamp01(token.y),
+        ownerId: typeof token.ownerId === 'string' ? token.ownerId : null,
+    };
+}
+
+function normalizeClientMapState(map) {
+    if (!map || typeof map !== 'object') {
+        return {
+            strokes: [],
+            tokens: [],
+            settings: { ...MAP_DEFAULT_SETTINGS },
+            paused: false,
+            updatedAt: null,
+        };
+    }
+    const strokes = Array.isArray(map.strokes)
+        ? map.strokes.map((stroke) => normalizeClientMapStroke(stroke)).filter(Boolean)
+        : [];
+    const tokens = Array.isArray(map.tokens)
+        ? map.tokens.map((token) => normalizeClientMapToken(token)).filter(Boolean)
+        : [];
+    return {
+        strokes,
+        tokens,
+        settings: {
+            allowPlayerDrawing: !!map.settings?.allowPlayerDrawing,
+            allowPlayerTokenMoves: !!map.settings?.allowPlayerTokenMoves,
+        },
+        paused: !!map.paused,
+        updatedAt: typeof map.updatedAt === 'string' ? map.updatedAt : null,
+    };
+}
+
+function describePlayerName(player) {
+    if (!player) return 'Player';
+    const name = player.character?.name;
+    if (typeof name === 'string' && name.trim()) return name.trim();
+    if (player.username) return player.username;
+    if (player.userId) return `Player ${player.userId.slice(0, 6)}`;
+    return 'Player';
+}
+
+function describePlayerTooltip(player) {
+    if (!player) return '';
+    const parts = [];
+    if (player.username) parts.push(`@${player.username}`);
+    const character = player.character || {};
+    if (character.profile?.class) parts.push(character.profile.class);
+    if (character.resources?.level) parts.push(`Level ${character.resources.level}`);
+    if (
+        character.resources?.hp !== undefined &&
+        character.resources?.maxHP !== undefined &&
+        character.resources.maxHP !== ''
+    ) {
+        parts.push(`HP ${character.resources.hp}/${character.resources.maxHP}`);
+    }
+    return parts.join(' · ');
+}
+
+function describeDemonTooltip(demon) {
+    if (!demon) return '';
+    const parts = [];
+    if (demon.arcana) parts.push(demon.arcana);
+    if (demon.alignment) parts.push(demon.alignment);
+    if (demon.level) parts.push(`Level ${demon.level}`);
+    return parts.join(' · ');
+}
+
+function MapTab({ game, me }) {
+    const isDM = game.dmId === me.id;
+    const [mapState, setMapState] = useState(() => normalizeClientMapState(game?.map));
+    useEffect(() => {
+        setMapState(normalizeClientMapState(game?.map));
+    }, [game.id, game?.map]);
+
+    const [tool, setTool] = useState('select');
+    const [brushColor, setBrushColor] = useState(MAP_BRUSH_COLORS[0]);
+    const [brushSize, setBrushSize] = useState(4);
+    const [draftStroke, setDraftStroke] = useState(null);
+    const [isDrawing, setIsDrawing] = useState(false);
+    const canvasRef = useRef(null);
+    const boardRef = useRef(null);
+    const [boardSize, setBoardSize] = useState({ width: 0, height: 0 });
+    const [dragging, setDragging] = useState(null);
+    const [dragPreview, setDragPreview] = useState(null);
+    const [playerChoice, setPlayerChoice] = useState('');
+    const [demonChoice, setDemonChoice] = useState('');
+    const [demonQuery, setDemonQuery] = useState('');
+
+    useEffect(() => {
+        if (!isDM && tool === 'draw' && (!mapState.settings.allowPlayerDrawing || mapState.paused)) {
+            setTool('select');
+        }
+    }, [isDM, mapState.paused, mapState.settings.allowPlayerDrawing, tool]);
+
+    useEffect(() => {
+        const board = boardRef.current;
+        if (!board || typeof ResizeObserver === 'undefined') {
+            return undefined;
+        }
+        const observer = new ResizeObserver((entries) => {
+            for (const entry of entries) {
+                setBoardSize({
+                    width: entry.contentRect.width,
+                    height: entry.contentRect.height,
+                });
+            }
+        });
+        observer.observe(board);
+        setBoardSize({ width: board.clientWidth, height: board.clientHeight });
+        return () => observer.disconnect();
+    }, []);
+
+    const canDraw = isDM || (!mapState.paused && mapState.settings.allowPlayerDrawing);
+    const canPaint = canDraw && tool === 'draw';
+    const tokenLayerPointerEvents = canPaint ? 'none' : 'auto';
+
+    const playerMap = useMemo(() => {
+        const map = new Map();
+        if (Array.isArray(game.players)) {
+            for (const player of game.players) {
+                if (!player || !player.userId) continue;
+                map.set(player.userId, player);
+            }
+        }
+        return map;
+    }, [game.players]);
+
+    const demonMap = useMemo(() => {
+        const map = new Map();
+        if (Array.isArray(game.demons)) {
+            for (const demon of game.demons) {
+                if (!demon || !demon.id) continue;
+                map.set(demon.id, demon);
+            }
+        }
+        return map;
+    }, [game.demons]);
+
+    const playerTokens = useMemo(
+        () => mapState.tokens.filter((token) => token.kind === 'player'),
+        [mapState.tokens]
+    );
+    const demonTokens = useMemo(
+        () => mapState.tokens.filter((token) => token.kind === 'demon'),
+        [mapState.tokens]
+    );
+
+    const availablePlayers = useMemo(() => {
+        if (!isDM) return [];
+        const taken = new Set(playerTokens.map((token) => token.refId));
+        return (game.players || [])
+            .filter(
+                (player) =>
+                    player &&
+                    player.userId &&
+                    (player.role || '').toLowerCase() !== 'dm' &&
+                    !taken.has(player.userId)
+            )
+            .map((player) => ({
+                id: player.userId,
+                label: describePlayerName(player),
+                subtitle: describePlayerTooltip(player),
+            }));
+    }, [game.players, isDM, playerTokens]);
+
+    const demonOptions = useMemo(() => {
+        if (!isDM) return [];
+        const term = demonQuery.trim().toLowerCase();
+        return (game.demons || [])
+            .filter(
+                (demon) =>
+                    demon &&
+                    demon.id &&
+                    (!term || (demon.name || '').toLowerCase().includes(term))
+            )
+            .slice(0, 25)
+            .map((demon) => ({
+                id: demon.id,
+                label: demon.name || 'Demon',
+                subtitle: describeDemonTooltip(demon),
+            }));
+    }, [demonQuery, game.demons, isDM]);
+
+    const getPointerPosition = useCallback(
+        (event) => {
+            const board = boardRef.current;
+            if (!board) return { x: 0, y: 0 };
+            const rect = board.getBoundingClientRect();
+            const clientX = event.clientX ?? (event.touches?.[0]?.clientX ?? 0);
+            const clientY = event.clientY ?? (event.touches?.[0]?.clientY ?? 0);
+            const x = rect.width ? (clientX - rect.left) / rect.width : 0;
+            const y = rect.height ? (clientY - rect.top) / rect.height : 0;
+            return { x: mapClamp01(x), y: mapClamp01(y) };
+        },
+        []
+    );
+
+    const sendStroke = useCallback(
+        async (strokePayload) => {
+            try {
+                const response = await Games.addMapStroke(game.id, strokePayload);
+                const normalized = normalizeClientMapStroke(response);
+                if (normalized) {
+                    setMapState((prev) => ({
+                        ...prev,
+                        strokes: prev.strokes.concat(normalized),
+                        updatedAt: response?.createdAt || prev.updatedAt,
+                    }));
+                }
+            } catch (err) {
+                alert(err.message);
+            }
+        },
+        [game.id]
+    );
+
+    const completeStroke = useCallback(() => {
+        setDraftStroke((current) => {
+            if (!current || current.points.length < 2) {
+                setIsDrawing(false);
+                return null;
+            }
+            sendStroke({
+                color: current.color,
+                size: current.size,
+                points: current.points,
+            });
+            setIsDrawing(false);
+            return null;
+        });
+    }, [sendStroke]);
+
+    const handleCanvasPointerDown = useCallback(
+        (event) => {
+            if (!canPaint) return;
+            event.preventDefault();
+            const { x, y } = getPointerPosition(event);
+            setDraftStroke({
+                id: `draft-${Date.now()}`,
+                color: brushColor,
+                size: brushSize,
+                points: [{ x, y }],
+            });
+            setIsDrawing(true);
+            const canvas = canvasRef.current;
+            if (canvas?.setPointerCapture) {
+                try {
+                    canvas.setPointerCapture(event.pointerId);
+                } catch {
+                    // ignore capture errors
+                }
+            }
+        },
+        [brushColor, brushSize, canPaint, getPointerPosition]
+    );
+
+    const handleCanvasPointerMove = useCallback(
+        (event) => {
+            if (!isDrawing) return;
+            const { x, y } = getPointerPosition(event);
+            setDraftStroke((prev) => {
+                if (!prev) return prev;
+                if (prev.points.length >= MAP_MAX_POINTS_PER_STROKE) return prev;
+                const last = prev.points[prev.points.length - 1];
+                if (last && Math.abs(last.x - x) < 0.002 && Math.abs(last.y - y) < 0.002) {
+                    return prev;
+                }
+                return { ...prev, points: prev.points.concat({ x, y }) };
+            });
+        },
+        [getPointerPosition, isDrawing]
+    );
+
+    const handleCanvasPointerFinish = useCallback(
+        (event) => {
+            if (canvasRef.current?.releasePointerCapture) {
+                try {
+                    canvasRef.current.releasePointerCapture(event.pointerId);
+                } catch {
+                    // ignore release errors
+                }
+            }
+            if (isDrawing || draftStroke) {
+                completeStroke();
+            }
+        },
+        [completeStroke, draftStroke, isDrawing]
+    );
+
+    useEffect(() => {
+        const canvas = canvasRef.current;
+        const board = boardRef.current;
+        if (!canvas || !board) return;
+        const width = boardSize.width || board.clientWidth;
+        const height = boardSize.height || board.clientHeight;
+        if (!width || !height) return;
+        const dpr = window.devicePixelRatio || 1;
+        if (canvas.width !== Math.floor(width * dpr) || canvas.height !== Math.floor(height * dpr)) {
+            canvas.width = Math.floor(width * dpr);
+            canvas.height = Math.floor(height * dpr);
+        }
+        const ctx = canvas.getContext('2d');
+        if (!ctx) return;
+        ctx.save();
+        ctx.scale(dpr, dpr);
+        ctx.clearRect(0, 0, width, height);
+        const strokes = [...mapState.strokes];
+        if (draftStroke) strokes.push(draftStroke);
+        for (const stroke of strokes) {
+            if (!stroke || stroke.points.length < 2) continue;
+            ctx.beginPath();
+            ctx.strokeStyle = stroke.color || MAP_BRUSH_COLORS[0];
+            ctx.lineWidth = stroke.size || 3;
+            ctx.lineJoin = 'round';
+            ctx.lineCap = 'round';
+            const first = stroke.points[0];
+            ctx.moveTo(first.x * width, first.y * height);
+            for (let i = 1; i < stroke.points.length; i += 1) {
+                const point = stroke.points[i];
+                ctx.lineTo(point.x * width, point.y * height);
+            }
+            ctx.stroke();
+        }
+        ctx.restore();
+    }, [boardSize.height, boardSize.width, draftStroke, mapState.strokes]);
+
+    const canMoveToken = useCallback(
+        (token) => {
+            if (!token) return false;
+            if (isDM) return true;
+            if (mapState.paused) return false;
+            if (!mapState.settings.allowPlayerTokenMoves) return false;
+            return token.ownerId === me.id;
+        },
+        [isDM, mapState.paused, mapState.settings.allowPlayerTokenMoves, me.id]
+    );
+
+    const handleTokenPointerDown = useCallback(
+        (token, event) => {
+            if (!canMoveToken(token)) return;
+            event.preventDefault();
+            event.stopPropagation();
+            const target = event.currentTarget;
+            if (target?.setPointerCapture) {
+                try {
+                    target.setPointerCapture(event.pointerId);
+                } catch {
+                    // ignore capture errors
+                }
+            }
+            const { x, y } = getPointerPosition(event);
+            setDragging({ id: token.id, pointerId: event.pointerId });
+            setDragPreview({ id: token.id, x, y });
+        },
+        [canMoveToken, getPointerPosition]
+    );
+
+    const handleTokenPointerMove = useCallback(
+        (token, event) => {
+            if (!dragging || dragging.id !== token.id) return;
+            const { x, y } = getPointerPosition(event);
+            setDragPreview({ id: token.id, x, y });
+        },
+        [dragging, getPointerPosition]
+    );
+
+    const handleTokenPointerUp = useCallback(
+        (token, event) => {
+            if (!dragging || dragging.id !== token.id) return;
+            const target = event.currentTarget;
+            if (target?.releasePointerCapture) {
+                try {
+                    target.releasePointerCapture(dragging.pointerId);
+                } catch {
+                    // ignore release errors
+                }
+            }
+            const coords =
+                dragPreview && dragPreview.id === token.id
+                    ? { x: dragPreview.x, y: dragPreview.y }
+                    : { x: token.x, y: token.y };
+            setDragging(null);
+            setDragPreview(null);
+            (async () => {
+                try {
+                    const response = await Games.updateMapToken(game.id, token.id, coords);
+                    const normalized = normalizeClientMapToken(response);
+                    setMapState((prev) => ({
+                        ...prev,
+                        tokens: prev.tokens.map((entry) =>
+                            entry.id === token.id
+                                ? normalized || { ...entry, x: coords.x, y: coords.y }
+                                : entry
+                        ),
+                        updatedAt: response?.updatedAt || prev.updatedAt,
+                    }));
+                } catch (err) {
+                    alert(err.message);
+                }
+            })();
+        },
+        [dragPreview, dragging, game.id]
+    );
+
+    const handleToggleTooltip = useCallback(
+        async (token, nextValue) => {
+            try {
+                const response = await Games.updateMapToken(game.id, token.id, {
+                    showTooltip: nextValue,
+                });
+                const normalized = normalizeClientMapToken(response);
+                if (normalized) {
+                    setMapState((prev) => ({
+                        ...prev,
+                        tokens: prev.tokens.map((entry) =>
+                            entry.id === normalized.id ? normalized : entry
+                        ),
+                        updatedAt: response?.updatedAt || prev.updatedAt,
+                    }));
+                }
+            } catch (err) {
+                alert(err.message);
+            }
+        },
+        [game.id]
+    );
+
+    const handleRemoveToken = useCallback(
+        async (token) => {
+            if (!isDM) return;
+            if (!confirm('Remove this token from the map?')) return;
+            try {
+                await Games.deleteMapToken(game.id, token.id);
+                setMapState((prev) => ({
+                    ...prev,
+                    tokens: prev.tokens.filter((entry) => entry.id !== token.id),
+                    updatedAt: new Date().toISOString(),
+                }));
+            } catch (err) {
+                alert(err.message);
+            }
+        },
+        [game.id, isDM]
+    );
+
+    const handleAddPlayerToken = useCallback(async () => {
+        if (!playerChoice) return;
+        try {
+            const response = await Games.addMapToken(game.id, {
+                kind: 'player',
+                refId: playerChoice,
+            });
+            const normalized = normalizeClientMapToken(response);
+            if (normalized) {
+                setMapState((prev) => ({
+                    ...prev,
+                    tokens: prev.tokens.concat(normalized),
+                    updatedAt: response?.updatedAt || prev.updatedAt,
+                }));
+            }
+            setPlayerChoice('');
+        } catch (err) {
+            alert(err.message);
+        }
+    }, [game.id, playerChoice]);
+
+    const handleAddDemonToken = useCallback(async () => {
+        if (!demonChoice) return;
+        try {
+            const response = await Games.addMapToken(game.id, {
+                kind: 'demon',
+                refId: demonChoice,
+            });
+            const normalized = normalizeClientMapToken(response);
+            if (normalized) {
+                setMapState((prev) => ({
+                    ...prev,
+                    tokens: prev.tokens.concat(normalized),
+                    updatedAt: response?.updatedAt || prev.updatedAt,
+                }));
+            }
+            setDemonChoice('');
+        } catch (err) {
+            alert(err.message);
+        }
+    }, [demonChoice, game.id]);
+
+    const handleToggleAllowDrawing = useCallback(async () => {
+        try {
+            const updated = await Games.updateMapSettings(game.id, {
+                allowPlayerDrawing: !mapState.settings.allowPlayerDrawing,
+            });
+            setMapState(normalizeClientMapState(updated));
+        } catch (err) {
+            alert(err.message);
+        }
+    }, [game.id, mapState.settings.allowPlayerDrawing]);
+
+    const handleToggleAllowMoves = useCallback(async () => {
+        try {
+            const updated = await Games.updateMapSettings(game.id, {
+                allowPlayerTokenMoves: !mapState.settings.allowPlayerTokenMoves,
+            });
+            setMapState(normalizeClientMapState(updated));
+        } catch (err) {
+            alert(err.message);
+        }
+    }, [game.id, mapState.settings.allowPlayerTokenMoves]);
+
+    const handleTogglePause = useCallback(async () => {
+        try {
+            const updated = await Games.updateMapSettings(game.id, { paused: !mapState.paused });
+            setMapState(normalizeClientMapState(updated));
+        } catch (err) {
+            alert(err.message);
+        }
+    }, [game.id, mapState.paused]);
+
+    const handleClearStrokes = useCallback(async () => {
+        if (!isDM) return;
+        if (!confirm('Clear all drawings from the map?')) return;
+        try {
+            await Games.clearMapStrokes(game.id);
+            setMapState((prev) => ({
+                ...prev,
+                strokes: [],
+                updatedAt: new Date().toISOString(),
+            }));
+        } catch (err) {
+            alert(err.message);
+        }
+    }, [game.id, isDM]);
+
+    return (
+        <div className="map-tab">
+            <div className="map-toolbar card">
+                <div className="map-toolbar__row">
+                    <div className="map-toolbar__tools">
+                        <span className="text-small">Tool</span>
+                        <div className="map-toolbar__buttons">
+                            <button
+                                type="button"
+                                className={`btn btn-small${tool === 'select' ? ' is-active' : ' secondary'}`}
+                                onClick={() => setTool('select')}
+                            >
+                                Select
+                            </button>
+                            <button
+                                type="button"
+                                className={`btn btn-small${tool === 'draw' ? ' is-active' : ' secondary'}`}
+                                onClick={() => setTool('draw')}
+                                disabled={!canDraw}
+                            >
+                                Draw
+                            </button>
+                        </div>
+                    </div>
+                    <div className="map-toolbar__status">
+                        <span className={`pill ${mapState.paused ? 'warn' : 'success'}`}>
+                            {mapState.paused ? 'Updates paused' : 'Live updates'}
+                        </span>
+                        {isDM && (
+                            <button type="button" className="btn btn-small" onClick={handleTogglePause}>
+                                {mapState.paused ? 'Resume sharing' : 'Pause updates'}
+                            </button>
+                        )}
+                    </div>
+                </div>
+                {canDraw && (
+                    <div className="map-toolbar__row map-toolbar__brush">
+                        <div>
+                            <span className="text-small">Brush color</span>
+                            <div className="map-toolbar__colors">
+                                {MAP_BRUSH_COLORS.map((color) => (
+                                    <button
+                                        key={color}
+                                        type="button"
+                                        className={`map-color${brushColor === color ? ' is-active' : ''}`}
+                                        style={{ background: color }}
+                                        onClick={() => setBrushColor(color)}
+                                    />
+                                ))}
+                            </div>
+                        </div>
+                        <label className="map-brush-size">
+                            <span className="text-small">Brush size</span>
+                            <input
+                                type="range"
+                                min="2"
+                                max="18"
+                                value={brushSize}
+                                onChange={(event) => setBrushSize(Number(event.target.value) || 4)}
+                            />
+                        </label>
+                    </div>
+                )}
+                {isDM && (
+                    <div className="map-toolbar__row map-toolbar__settings">
+                        <label className="perm-toggle">
+                            <input
+                                type="checkbox"
+                                checked={mapState.settings.allowPlayerDrawing}
+                                onChange={handleToggleAllowDrawing}
+                            />
+                            <span className="perm-toggle__text">Allow players to draw</span>
+                        </label>
+                        <label className="perm-toggle">
+                            <input
+                                type="checkbox"
+                                checked={mapState.settings.allowPlayerTokenMoves}
+                                onChange={handleToggleAllowMoves}
+                            />
+                            <span className="perm-toggle__text">Allow players to move their token</span>
+                        </label>
+                        <button
+                            type="button"
+                            className="btn ghost btn-small"
+                            onClick={handleClearStrokes}
+                            disabled={mapState.strokes.length === 0}
+                        >
+                            Clear drawings
+                        </button>
+                    </div>
+                )}
+            </div>
+            <div className="map-layout">
+                <div className="map-board card" ref={boardRef}>
+                    <canvas
+                        ref={canvasRef}
+                        className="map-board__canvas"
+                        onPointerDown={handleCanvasPointerDown}
+                        onPointerMove={handleCanvasPointerMove}
+                        onPointerUp={handleCanvasPointerFinish}
+                        onPointerCancel={handleCanvasPointerFinish}
+                        onPointerLeave={handleCanvasPointerFinish}
+                    />
+                    <div className="map-board__tokens" style={{ pointerEvents: tokenLayerPointerEvents }}>
+                        {mapState.tokens.map((token) => {
+                            const player = token.kind === 'player' ? playerMap.get(token.refId) : null;
+                            const demon = token.kind === 'demon' ? demonMap.get(token.refId) : null;
+                            const display = dragPreview && dragPreview.id === token.id
+                                ? { ...token, x: dragPreview.x, y: dragPreview.y }
+                                : token;
+                            const showTooltip = token.showTooltip && token.tooltip;
+                            const canDrag = canMoveToken(token);
+                            const label = token.label || (player ? describePlayerName(player) : demon ? demon.name : 'Marker');
+                            return (
+                                <button
+                                    key={token.id}
+                                    type="button"
+                                    className={`map-token map-token--${token.kind}${canDrag ? ' is-draggable' : ''}`}
+                                    style={{ left: `${display.x * 100}%`, top: `${display.y * 100}%`, background: token.color }}
+                                    onPointerDown={(event) => handleTokenPointerDown(token, event)}
+                                    onPointerMove={(event) => handleTokenPointerMove(token, event)}
+                                    onPointerUp={(event) => handleTokenPointerUp(token, event)}
+                                    onPointerCancel={(event) => handleTokenPointerUp(token, event)}
+                                >
+                                    <span className="map-token__label">{label.slice(0, 2).toUpperCase()}</span>
+                                    {showTooltip && <span className="map-token__tooltip">{token.tooltip}</span>}
+                                </button>
+                            );
+                        })}
+                    </div>
+                    {mapState.paused && !isDM && (
+                        <div className="map-board__overlay">
+                            <div className="map-board__overlay-content">
+                                <span className="pill warn">Updates paused</span>
+                                <p>The DM is preparing the battlefield. Drawings and token moves will appear once play resumes.</p>
+                            </div>
+                        </div>
+                    )}
+                </div>
+                <aside className="map-sidebar">
+                    <div className="map-panel card">
+                        <h3>Player tokens</h3>
+                        {isDM && availablePlayers.length > 0 && (
+                            <div className="map-panel__add">
+                                <label className="text-small" htmlFor="map-add-player">Add party member</label>
+                                <div className="row" style={{ gap: 8, flexWrap: 'wrap' }}>
+                                    <select
+                                        id="map-add-player"
+                                        value={playerChoice}
+                                        onChange={(event) => setPlayerChoice(event.target.value)}
+                                    >
+                                        <option value="">Select a player…</option>
+                                        {availablePlayers.map((player) => (
+                                            <option key={player.id} value={player.id}>
+                                                {player.label}
+                                            </option>
+                                        ))}
+                                    </select>
+                                    <button
+                                        type="button"
+                                        className="btn btn-small"
+                                        onClick={handleAddPlayerToken}
+                                        disabled={!playerChoice}
+                                    >
+                                        Place token
+                                    </button>
+                                </div>
+                            </div>
+                        )}
+                        {playerTokens.length === 0 ? (
+                            <p className="map-empty text-muted">No party members on the board yet.</p>
+                        ) : (
+                            <div className="list">
+                                {playerTokens.map((token) => {
+                                    const player = playerMap.get(token.refId);
+                                    const label = token.label || describePlayerName(player);
+                                    const subtitle = describePlayerTooltip(player);
+                                    return (
+                                        <div key={token.id} className="map-token-row">
+                                            <div>
+                                                <strong>{label}</strong>
+                                                {subtitle && <div className="text-muted text-small">{subtitle}</div>}
+                                            </div>
+                                            {isDM && (
+                                                <div className="row" style={{ gap: 8 }}>
+                                                    <label className="perm-toggle">
+                                                        <input
+                                                            type="checkbox"
+                                                            checked={token.showTooltip}
+                                                            onChange={(event) => handleToggleTooltip(token, event.target.checked)}
+                                                        />
+                                                        <span className="perm-toggle__text">Tooltip</span>
+                                                    </label>
+                                                    <button
+                                                        type="button"
+                                                        className="btn ghost btn-small"
+                                                        onClick={() => handleRemoveToken(token)}
+                                                    >
+                                                        Remove
+                                                    </button>
+                                                </div>
+                                            )}
+                                        </div>
+                                    );
+                                })}
+                            </div>
+                        )}
+                    </div>
+                    <div className="map-panel card">
+                        <h3>Companion tokens</h3>
+                        {isDM && (
+                            <div className="map-panel__add">
+                                <label className="text-small" htmlFor="map-demon-search">Search codex</label>
+                                <input
+                                    id="map-demon-search"
+                                    type="text"
+                                    value={demonQuery}
+                                    onChange={(event) => setDemonQuery(event.target.value)}
+                                    placeholder="Filter demons…"
+                                />
+                                <div className="row" style={{ gap: 8, flexWrap: 'wrap' }}>
+                                    <select
+                                        value={demonChoice}
+                                        onChange={(event) => setDemonChoice(event.target.value)}
+                                    >
+                                        <option value="">Select a demon…</option>
+                                        {demonOptions.map((option) => (
+                                            <option key={option.id} value={option.id}>
+                                                {option.label}
+                                            </option>
+                                        ))}
+                                    </select>
+                                    <button
+                                        type="button"
+                                        className="btn btn-small"
+                                        onClick={handleAddDemonToken}
+                                        disabled={!demonChoice}
+                                    >
+                                        Summon
+                                    </button>
+                                </div>
+                            </div>
+                        )}
+                        {demonTokens.length === 0 ? (
+                            <p className="map-empty text-muted">No companions placed.</p>
+                        ) : (
+                            <div className="list">
+                                {demonTokens.map((token) => {
+                                    const demon = demonMap.get(token.refId);
+                                    const label = token.label || demon?.name || 'Demon';
+                                    const subtitle = describeDemonTooltip(demon);
+                                    return (
+                                        <div key={token.id} className="map-token-row">
+                                            <div>
+                                                <strong>{label}</strong>
+                                                {subtitle && <div className="text-muted text-small">{subtitle}</div>}
+                                            </div>
+                                            {isDM && (
+                                                <div className="row" style={{ gap: 8 }}>
+                                                    <label className="perm-toggle">
+                                                        <input
+                                                            type="checkbox"
+                                                            checked={token.showTooltip}
+                                                            onChange={(event) => handleToggleTooltip(token, event.target.checked)}
+                                                        />
+                                                        <span className="perm-toggle__text">Tooltip</span>
+                                                    </label>
+                                                    <button
+                                                        type="button"
+                                                        className="btn ghost btn-small"
+                                                        onClick={() => handleRemoveToken(token)}
+                                                    >
+                                                        Remove
+                                                    </button>
+                                                </div>
+                                            )}
+                                        </div>
+                                    );
+                                })}
+                            </div>
+                        )}
+                    </div>
+                </aside>
+            </div>
+        </div>
     );
 }
 

--- a/web/src/api.js
+++ b/web/src/api.js
@@ -447,6 +447,24 @@ export const Games = {
     updateDemon: (id, demonId, body) => api(`/api/games/${encodeURIComponent(id)}/demons/${encodeURIComponent(demonId)}`, { method: 'PUT', body }),
     delDemon: (id, demonId) => api(`/api/games/${encodeURIComponent(id)}/demons/${encodeURIComponent(demonId)}`, { method: 'DELETE' }),
 
+    updateMapSettings: (id, settings) =>
+        api(`/api/games/${encodeURIComponent(id)}/map/settings`, { method: 'PUT', body: settings }),
+    addMapStroke: (id, stroke) =>
+        api(`/api/games/${encodeURIComponent(id)}/map/strokes`, { method: 'POST', body: { stroke } }),
+    deleteMapStroke: (id, strokeId) =>
+        api(`/api/games/${encodeURIComponent(id)}/map/strokes/${encodeURIComponent(strokeId)}`, { method: 'DELETE' }),
+    clearMapStrokes: (id) =>
+        api(`/api/games/${encodeURIComponent(id)}/map/strokes/clear`, { method: 'POST' }),
+    addMapToken: (id, token) =>
+        api(`/api/games/${encodeURIComponent(id)}/map/tokens`, { method: 'POST', body: token }),
+    updateMapToken: (id, tokenId, payload) =>
+        api(`/api/games/${encodeURIComponent(id)}/map/tokens/${encodeURIComponent(tokenId)}`, {
+            method: 'PUT',
+            body: payload,
+        }),
+    deleteMapToken: (id, tokenId) =>
+        api(`/api/games/${encodeURIComponent(id)}/map/tokens/${encodeURIComponent(tokenId)}`, { method: 'DELETE' }),
+
     // Optional: full pagination helper example if the backend supports it
     listAll: (query) => apiClient.getAllPages('/api/games', { query }),
 };

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -376,6 +376,234 @@ p  { margin: 0 0 .75rem; color: var(--text); }
     background: var(--surface);
 }
 
+/* Battle map */
+.map-tab {
+    display: grid;
+    gap: 16px;
+}
+
+.map-toolbar {
+    display: grid;
+    gap: 12px;
+}
+
+.map-toolbar__row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 12px;
+}
+
+.map-toolbar__tools {
+    display: grid;
+    gap: 6px;
+}
+
+.map-toolbar__buttons {
+    display: flex;
+    gap: 8px;
+}
+
+.map-toolbar .btn.is-active {
+    box-shadow: var(--focus);
+}
+
+.map-toolbar__status {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+}
+
+.map-toolbar__brush {
+    display: flex;
+    align-items: center;
+    gap: 24px;
+    flex-wrap: wrap;
+}
+
+.map-toolbar__colors {
+    display: flex;
+    gap: 6px;
+}
+
+.map-color {
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    border: 2px solid transparent;
+    cursor: pointer;
+    transition: transform var(--trans-fast), border-color var(--trans-fast), box-shadow var(--trans-fast);
+}
+
+.map-color:hover {
+    transform: translateY(-2px);
+}
+
+.map-color.is-active {
+    border-color: rgba(255, 255, 255, 0.8);
+    box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.35), 0 0 0 4px rgba(15, 23, 42, 0.2);
+}
+
+.map-brush-size {
+    display: grid;
+    gap: 6px;
+    min-width: 160px;
+}
+
+.map-toolbar__settings {
+    gap: 16px;
+    align-items: center;
+    flex-wrap: wrap;
+}
+
+.map-layout {
+    display: grid;
+    gap: 16px;
+    grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+    align-items: start;
+}
+
+@media (max-width: 960px) {
+    .map-layout {
+        grid-template-columns: minmax(0, 1fr);
+    }
+}
+
+.map-board {
+    position: relative;
+    padding: 0;
+    overflow: hidden;
+    min-height: 400px;
+    border-radius: var(--radius-lg);
+}
+
+.map-board__canvas {
+    width: 100%;
+    height: 100%;
+    display: block;
+    touch-action: none;
+    background: linear-gradient(135deg, rgba(59, 130, 246, 0.06), rgba(59, 130, 246, 0.12));
+}
+
+.map-board__tokens {
+    position: absolute;
+    inset: 0;
+}
+
+.map-token {
+    position: absolute;
+    transform: translate(-50%, -50%);
+    border-radius: 999px;
+    min-width: 34px;
+    min-height: 34px;
+    border: 2px solid rgba(255, 255, 255, 0.75);
+    box-shadow: 0 6px 16px rgba(15, 23, 42, 0.35);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #fff;
+    font-weight: 700;
+    letter-spacing: .05em;
+    cursor: default;
+    transition: transform var(--trans-fast), box-shadow var(--trans-fast);
+}
+
+.map-token.is-draggable {
+    cursor: grab;
+}
+
+.map-token.is-draggable:hover {
+    transform: translate(-50%, -50%) scale(1.06);
+    box-shadow: 0 10px 20px rgba(15, 23, 42, 0.45);
+}
+
+.map-token__label {
+    pointer-events: none;
+}
+
+.map-token__tooltip {
+    position: absolute;
+    bottom: calc(100% + 10px);
+    left: 50%;
+    transform: translateX(-50%);
+    background: rgba(15, 23, 42, 0.92);
+    color: #fff;
+    padding: 6px 10px;
+    border-radius: 8px;
+    font-size: 12px;
+    white-space: nowrap;
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity var(--trans-fast), transform var(--trans-fast);
+}
+
+.map-token:hover .map-token__tooltip {
+    opacity: 1;
+    transform: translate(-50%, -2px);
+}
+
+.map-token--player {
+    border-color: rgba(56, 189, 248, 0.75);
+}
+
+.map-token--demon {
+    border-color: rgba(249, 115, 22, 0.75);
+}
+
+.map-board__overlay {
+    position: absolute;
+    inset: 0;
+    display: grid;
+    place-items: center;
+    background: rgba(15, 23, 42, 0.55);
+    padding: 24px;
+    text-align: center;
+}
+
+.map-board__overlay-content {
+    background: rgba(17, 24, 39, 0.85);
+    border-radius: var(--radius);
+    padding: 16px 20px;
+    max-width: min(420px, 90%);
+    color: #e5e7eb;
+    display: grid;
+    gap: 8px;
+}
+
+.map-sidebar {
+    display: grid;
+    gap: 16px;
+}
+
+.map-panel {
+    display: grid;
+    gap: 12px;
+}
+
+.map-panel__add {
+    display: grid;
+    gap: 8px;
+}
+
+.map-token-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 12px;
+    padding: 10px 0;
+    border-bottom: 1px solid var(--border);
+}
+
+.map-token-row:last-child {
+    border-bottom: none;
+}
+
+.map-empty {
+    margin: 4px 0 0;
+}
+
 /* Gear overview */
 .gear-overview-card {
     display: grid;


### PR DESCRIPTION
## Summary
- add normalized battle map state on the server plus REST endpoints for settings, strokes, and tokens guarded by map permissions
- broadcast map updates over existing game websocket updates so live viewers stay in sync while respecting DM pause controls
- expose map APIs on the client, add a Battle Map tab with drawing, token placement, drag interactions, and supporting styles

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d09709eabc83319c4f14c09df6233c