### PR TITLE
feat: migrate to MongoDB and refresh discord tools

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,15 +1,21 @@
-# Discord story log sync configuration for the backend server
-DISCORD_BOT_TOKEN=
-DISCORD_CHANNEL_ID=
+# Core application configuration
+MONGODB_URI=mongodb://localhost:27017/jack-endex
+MONGODB_DB_NAME=jack-endex
+SESSION_SECRET=change-me-in-production
 
-# Optional server overrides
-DISCORD_GUILD_ID=
+# Optional shared Discord bot used when campaigns do not supply their own token
+DISCORD_PRIMARY_BOT_TOKEN=
+DISCORD_PRIMARY_BOT_INVITE=
+DISCORD_APPLICATION_ID=
+DISCORD_PRIMARY_GUILD_ID=
+DISCORD_PRIMARY_CHANNEL_ID=
+DISCORD_COMMAND_GUILD_ID=
+
+# Legacy fallback keys (optional)
+DISCORD_DEFAULT_BOT_TOKEN=
+DISCORD_BOT_TOKEN=
+BOT_TOKEN=
+
+# Story watcher defaults
 DISCORD_POLL_INTERVAL_MS=15000
 DISCORD_MAX_MESSAGES=50
-
-# Discord story log embed configuration for Vite (frontend)
-VITE_DISCORD_SERVER_ID=
-VITE_DISCORD_CHANNEL_ID=
-# Optional overrides
-VITE_DISCORD_WIDGET_BASE=https://e.widgetbot.io/channels
-VITE_DISCORD_WIDGET_THEME=dark

--- a/README.md
+++ b/README.md
@@ -1,35 +1,96 @@
-# React + Vite
+# Jack Endex Campaign Dashboard
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+Jack Endex is a full-stack toolkit for running tabletop campaigns with a digital codex, combat tracker, and Discord integration. The backend is powered by Express and MongoDB, while the client is a React + Vite single-page app.
 
-Currently, two official plugins are available:
+## Prerequisites
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+- [Node.js 18+](https://nodejs.org/)
+- [MongoDB](https://www.mongodb.com/) connection that the server can reach
 
-## Expanding the ESLint configuration
+## Getting started
 
-If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
-
-## Discord story log sync
-
-The in-app **Story Logs** tab now both reads and posts messages through the backend. To wire things up:
-
-1. Invite a Discord bot that can view your campaign channels. Each campaign may use its own bot token, or you can provide a shared fallback token before starting `node server.js`:
+1. Install dependencies:
 
    ```bash
-   export DISCORD_BOT_TOKEN="<optional fallback bot token with read history access>"
+   npm install
    ```
 
-   Use [the Discord developer portal](https://discord.com/developers/applications) to create a bot and invite it with the `Read Messages/View Channel` and `Read Message History` permissions. If the webhook will post to a different server, also grant it access there.
+2. Copy `.env.example` to `.env` and fill in the required values. At minimum you must provide:
 
-2. Inside the app, each campaign's **Settings → Discord story integration** panel lets the DM supply:
+   ```ini
+   MONGODB_URI=mongodb://localhost:27017/jack-endex
+   SESSION_SECRET=use-a-strong-secret
+   ```
 
-   - A Discord bot token dedicated to that campaign (falls back to the shared token if omitted).
+   You can optionally supply a shared Discord bot token and invite link so every campaign can fall back to the same bot. Dungeon Masters may still provide their own tokens per campaign inside the app.
 
-   - The Discord channel snowflake to watch.
-   - An optional guild ID used for validation and jump links.
-   - A Discord webhook URL that determines how outbound messages appear.
-   - Whether players may post from the dashboard and which players can act as **Scribes**.
+3. Import the demon codex into MongoDB (run with `--dry-run` first if you want to preview changes):
 
-Once saved, the Story tab shows live channel activity, allows approved users to speak as the bot, Dungeon Master, Scribe, or specific players, and renders Discord image attachments inline.
+   ```bash
+   npm run import:demons -- --dry-run
+   npm run import:demons
+   ```
+
+4. Start the development servers (REST API + Vite dev client):
+
+   ```bash
+   npm run dev
+   ```
+
+   The API listens on `http://localhost:3000` and the React client on `http://localhost:5173`.
+
+## Discord integration
+
+### Story synchronization
+
+Each campaign can read and post to a dedicated Discord channel. In **Settings → Discord story integration** the DM can set:
+
+- A per-campaign bot token (optional if you configure a shared token in `.env`).
+- Channel and guild snowflakes to watch.
+- A webhook URL for posting as the bot, DM, scribe, or specific players.
+- Player permissions and scribe access.
+
+If no per-campaign token is supplied, the server falls back to `DISCORD_PRIMARY_BOT_TOKEN` (or the legacy keys) defined in your environment.
+
+### Slash command codex lookup
+
+A lightweight gateway client powers the `/lookup demon <name>` slash command. To enable it:
+
+1. Set `DISCORD_APPLICATION_ID` and `DISCORD_PRIMARY_BOT_TOKEN` in your `.env`. Optionally set `DISCORD_COMMAND_GUILD_ID` for per-guild registration and `DISCORD_PRIMARY_BOT_INVITE` so DMs can invite the shared bot to their own servers.
+
+2. Register the command with Discord:
+
+   ```bash
+   npm run register:discord
+   ```
+
+3. Run the lookup bot (ensure MongoDB is reachable so it can query the codex):
+
+   ```bash
+   npm run bot:demon
+   ```
+
+The bot listens for slash-command interactions and responds with a formatted codex summary, including close-match suggestions for typos.
+
+## Helpful scripts
+
+| Command | Description |
+| --- | --- |
+| `npm run import:demons` | Convert `data/demons.json` into MongoDB documents (use `--dry-run` to preview). |
+| `npm run test:import` | Runs the demon import in dry-run mode to confirm the mapping step. |
+| `npm run register:discord` | Registers or updates the `/lookup demon` slash command. |
+| `npm run bot:demon` | Starts the Discord gateway bot that powers the slash command. |
+| `npm run dev` | Runs the API server and Vite dev client together. |
+| `npm run start` | Launches the API server only (expects a built client in `dist/`). |
+| `npm run build` | Builds the production React bundle. |
+| `npm run lint` | Lints the entire project. |
+
+## Importing additional data
+
+The importer lives in `scripts/import-demons.js`. The module exports `importDemons()` so you can integrate it into other build pipelines if needed. Pass `{ dropMissing: false }` to keep existing MongoDB entries that are not present in the JSON source.
+
+## Matrix rain and UI polish
+
+The background activity indicator (matrix rain) now reacts to both API traffic and URL changes, keeping the motion synced as you navigate between campaign views. The demon codex tab has also been refreshed with a new card layout for faster scanning of stats, resistances, and skill loads.
+
+Happy demon wrangling!

--- a/bot/demonLookupBot.js
+++ b/bot/demonLookupBot.js
@@ -1,0 +1,236 @@
+import path from 'path';
+import { fileURLToPath } from 'url';
+import WebSocket from 'ws';
+import { loadEnv, envString } from '../config/env.js';
+import mongoose from '../lib/mongoose.js';
+import {
+    searchDemons,
+    findDemonBySlug,
+    findClosestDemon,
+    summarizeDemon,
+    buildDemonDetailString,
+} from '../services/demons.js';
+
+const API_BASE = 'https://discord.com/api/v10';
+const GATEWAY_URL = 'wss://gateway.discord.gg/?v=10&encoding=json';
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+await loadEnv({ root: path.resolve(__dirname, '..') });
+
+const token = envString('DISCORD_PRIMARY_BOT_TOKEN')
+    || envString('DISCORD_DEFAULT_BOT_TOKEN')
+    || envString('DISCORD_BOT_TOKEN')
+    || envString('BOT_TOKEN');
+const uri = envString('MONGODB_URI');
+const dbName = envString('MONGODB_DB_NAME');
+
+if (!token) {
+    console.error('Missing bot token. Set DISCORD_PRIMARY_BOT_TOKEN or DISCORD_BOT_TOKEN in your .env file.');
+    process.exit(1);
+}
+if (!uri) {
+    console.error('Missing MONGODB_URI environment variable.');
+    process.exit(1);
+}
+
+await mongoose.connect(uri, { dbName: dbName || undefined });
+console.log('[bot] Connected to MongoDB. Starting gateway connection…');
+
+const ABILITY_KEYS = ['STR', 'DEX', 'CON', 'INT', 'WIS', 'CHA'];
+const RESIST_KEYS = [
+    ['weak', 'Weak'],
+    ['resist', 'Resist'],
+    ['null', 'Null'],
+    ['absorb', 'Absorb'],
+    ['reflect', 'Reflect'],
+];
+
+function truncate(text, max = 1024) {
+    if (!text) return '';
+    return text.length <= max ? text : `${text.slice(0, max - 1)}…`;
+}
+
+function formatDemonResponse(demon) {
+    const lines = [];
+    const summary = buildDemonDetailString(demon);
+    lines.push(`**${demon.name}**${summary ? ` · ${summary}` : ''}`);
+    if (demon.description) {
+        lines.push(truncate(demon.description, 400));
+    }
+    const stats = ABILITY_KEYS.map((key) => `${key} ${demon.stats?.[key] ?? 0}`).join(' · ');
+    lines.push(`Stats: ${stats}`);
+    const resistParts = RESIST_KEYS.map(([key, label]) => {
+        const values = Array.isArray(demon.resistances?.[key]) ? demon.resistances[key] : [];
+        return `${label}: ${values.length ? values.join(', ') : '—'}`;
+    });
+    lines.push(resistParts.join(' · '));
+    if (Array.isArray(demon.skills) && demon.skills.length > 0) {
+        const skills = demon.skills
+            .slice(0, 6)
+            .map((skill) => {
+                const suffix = [];
+                if (skill.element) suffix.push(skill.element);
+                if (skill.cost) suffix.push(`${skill.cost}`);
+                const meta = suffix.length > 0 ? ` (${suffix.join(' · ')})` : '';
+                return `• ${skill.name}${meta}`;
+            });
+        if (demon.skills.length > skills.length) {
+            skills.push(`…and ${demon.skills.length - skills.length} more skills`);
+        }
+        lines.push(skills.join('\n'));
+    }
+    if (demon.image) {
+        lines.push(demon.image);
+    }
+    return lines.join('\n');
+}
+
+async function resolveDemon(term) {
+    const normalized = term.trim();
+    if (!normalized) return null;
+    const slug = normalized.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+    let demon = slug ? await findDemonBySlug(slug) : null;
+    if (!demon) {
+        const [hit] = await searchDemons(normalized, { limit: 1 });
+        if (hit) demon = hit;
+    }
+    return demon ? summarizeDemon(demon) : null;
+}
+
+async function respond(interaction, payload) {
+    const url = `${API_BASE}/interactions/${interaction.id}/${interaction.token}/callback`;
+    await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ type: 4, data: { ...payload, flags: 64 } }),
+    });
+}
+
+async function handleInteraction(interaction) {
+    if (interaction.type !== 2) return; // application command
+    const name = interaction.data?.name;
+    if (name !== 'lookup') return;
+    const sub = interaction.data?.options?.[0];
+    if (!sub || sub.name !== 'demon') {
+        await respond(interaction, { content: 'Unknown subcommand.' });
+        return;
+    }
+    const option = Array.isArray(sub.options)
+        ? sub.options.find((opt) => opt.name === 'name')
+        : null;
+    const term = option?.value || option?.name || '';
+    if (!term) {
+        await respond(interaction, { content: 'Provide a demon name to look up.' });
+        return;
+    }
+    try {
+        const demon = await resolveDemon(String(term));
+        if (demon) {
+            const message = formatDemonResponse(demon);
+            await respond(interaction, { content: message });
+        } else {
+            const suggestion = await findClosestDemon(String(term));
+            if (suggestion) {
+                await respond(interaction, {
+                    content: `No exact match. Did you mean **${suggestion.name}**? Try \`/lookup demon ${suggestion.name}\`.`,
+                });
+            } else {
+                await respond(interaction, { content: `No demon found matching **${term}**.` });
+            }
+        }
+    } catch (err) {
+        console.error('Failed to handle interaction:', err);
+        await respond(interaction, { content: 'Something went wrong looking up that demon.' });
+    }
+}
+
+function startGateway() {
+    let ws;
+    let heartbeatInterval = null;
+    let sequence = null;
+
+    function cleanup() {
+        if (heartbeatInterval) {
+            clearInterval(heartbeatInterval);
+            heartbeatInterval = null;
+        }
+    }
+
+    function connect() {
+        ws = new WebSocket(GATEWAY_URL);
+
+        ws.on('message', async (data) => {
+            const payload = JSON.parse(data.toString());
+            const { op, t, d, s } = payload;
+            if (s !== null && s !== undefined) {
+                sequence = s;
+            }
+            switch (op) {
+                case 10: { // Hello
+                    cleanup();
+                    heartbeatInterval = setInterval(() => {
+                        if (ws.readyState === WebSocket.OPEN) {
+                            ws.send(JSON.stringify({ op: 1, d: sequence }));
+                        }
+                    }, d.heartbeat_interval);
+                    ws.send(JSON.stringify({
+                        op: 2,
+                        d: {
+                            token,
+                            intents: 0,
+                            properties: {
+                                os: process.platform,
+                                browser: 'jack-endex',
+                                device: 'jack-endex',
+                            },
+                        },
+                    }));
+                    break;
+                }
+                case 0: {
+                    if (t === 'READY') {
+                        console.log(`[bot] Logged in as ${d.user?.username ?? 'bot'}.`);
+                    } else if (t === 'INTERACTION_CREATE') {
+                        await handleInteraction(d);
+                    }
+                    break;
+                }
+                case 7: { // Reconnect
+                    console.log('[bot] Gateway requested reconnect.');
+                    cleanup();
+                    ws.close(4000, 'Reconnect requested');
+                    break;
+                }
+                case 9: {
+                    console.warn('[bot] Invalid session. Re-identifying…');
+                    cleanup();
+                    ws.close(4001, 'Invalid session');
+                    break;
+                }
+                default:
+                    break;
+            }
+        });
+
+        ws.on('close', (code) => {
+            cleanup();
+            console.warn(`[bot] Gateway closed (${code}). Reconnecting in 5s…`);
+            setTimeout(connect, 5000);
+        });
+
+        ws.on('error', (err) => {
+            console.error('[bot] Gateway error:', err);
+            ws.close(1011, 'error');
+        });
+    }
+
+    connect();
+}
+
+startGateway();
+
+process.on('SIGINT', async () => {
+    console.log('\n[bot] Shutting down…');
+    await mongoose.disconnect();
+    process.exit(0);
+});

--- a/config/env.js
+++ b/config/env.js
@@ -1,0 +1,85 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PROJECT_ROOT = path.resolve(__dirname, '..');
+const loadedEnvKeys = new Set();
+
+function parseEnvFile(content) {
+    const entries = new Map();
+    if (typeof content !== 'string' || !content) return entries;
+    for (const rawLine of content.split(/\r?\n/)) {
+        const line = rawLine.trim();
+        if (!line || line.startsWith('#')) continue;
+        const withoutExport = line.startsWith('export ')
+            ? line.slice(7).trim()
+            : line;
+        const eqIndex = withoutExport.indexOf('=');
+        if (eqIndex === -1) continue;
+        const key = withoutExport.slice(0, eqIndex).trim();
+        if (!key) continue;
+        let value = withoutExport.slice(eqIndex + 1).trim();
+        if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+            value = value.slice(1, -1);
+        } else {
+            const commentIndex = value.indexOf(' #');
+            if (commentIndex !== -1) {
+                value = value.slice(0, commentIndex).trimEnd();
+            }
+        }
+        entries.set(key, value);
+    }
+    return entries;
+}
+
+function applyEnv(entries, { overrideLoaded = false } = {}) {
+    for (const [key, value] of entries) {
+        const hasExisting = Object.prototype.hasOwnProperty.call(process.env, key);
+        if (!hasExisting || (overrideLoaded && loadedEnvKeys.has(key))) {
+            process.env[key] = value;
+            loadedEnvKeys.add(key);
+        }
+    }
+}
+
+export async function loadEnv({ root = PROJECT_ROOT, files = ['.env', '.env.local'] } = {}) {
+    for (const file of files) {
+        const filePath = path.join(root, file);
+        try {
+            const content = await fs.readFile(filePath, 'utf8');
+            const entries = parseEnvFile(content.replace(/^\uFEFF/, ''));
+            applyEnv(entries, { overrideLoaded: file.endsWith('.local') });
+        } catch (err) {
+            if (err && err.code !== 'ENOENT') {
+                console.warn(`Failed to read ${file}:`, err);
+            }
+        }
+    }
+}
+
+export function envString(key, fallback = '') {
+    const value = process.env[key];
+    if (typeof value === 'string') {
+        const trimmed = value.trim();
+        if (trimmed) return trimmed;
+    }
+    return fallback;
+}
+
+export function envNumber(key, fallback = null) {
+    const raw = envString(key, '');
+    if (!raw) return fallback;
+    const num = Number(raw);
+    if (!Number.isFinite(num)) return fallback;
+    return num;
+}
+
+export function envBoolean(key, fallback = false) {
+    const raw = envString(key, '').toLowerCase();
+    if (!raw) return fallback;
+    if (['1', 'true', 'yes', 'on'].includes(raw)) return true;
+    if (['0', 'false', 'no', 'off'].includes(raw)) return false;
+    return fallback;
+}
+

--- a/discordWatcher.js
+++ b/discordWatcher.js
@@ -322,9 +322,14 @@ export function createDiscordWatcher({
 
 export function createWatcherFromEnv(env = process.env) {
     return createDiscordWatcher({
-        token: env.DISCORD_BOT_TOKEN || env.BOT_TOKEN,
-        guildId: env.DISCORD_GUILD_ID || env.DISCORD_SERVER_ID,
-        channelId: env.DISCORD_CHANNEL_ID,
+        token: env.DISCORD_BOT_TOKEN
+            || env.DISCORD_PRIMARY_BOT_TOKEN
+            || env.DISCORD_DEFAULT_BOT_TOKEN
+            || env.BOT_TOKEN,
+        guildId: env.DISCORD_GUILD_ID
+            || env.DISCORD_PRIMARY_GUILD_ID
+            || env.DISCORD_SERVER_ID,
+        channelId: env.DISCORD_CHANNEL_ID || env.DISCORD_PRIMARY_CHANNEL_ID,
         pollIntervalMs: env.DISCORD_POLL_INTERVAL_MS,
         maxMessages: env.DISCORD_MAX_MESSAGES,
     });

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -15,7 +15,10 @@ export default defineConfig([
     ],
     languageOptions: {
       ecmaVersion: 2020,
-      globals: globals.browser,
+      globals: {
+        ...globals.browser,
+        ...globals.node,
+      },
       parserOptions: {
         ecmaVersion: 'latest',
         ecmaFeatures: { jsx: true },

--- a/lib/mongoose.js
+++ b/lib/mongoose.js
@@ -1,0 +1,15 @@
+let mongooseModule;
+try {
+    const imported = await import('mongoose');
+    mongooseModule = imported.default ?? imported;
+} catch (err) {
+    if (process.env.MOCK_MONGOOSE === 'true') {
+        const mock = await import('./mockMongoose.js');
+        mongooseModule = mock.default ?? mock;
+        console.warn('[mock] Using in-memory mongoose stub.');
+    } else {
+        throw err;
+    }
+}
+
+export default mongooseModule;

--- a/models/Demon.js
+++ b/models/Demon.js
@@ -1,0 +1,65 @@
+import mongoose from '../lib/mongoose.js';
+
+const resistanceSchema = new mongoose.Schema(
+    {
+        weak: { type: [String], default: [] },
+        resist: { type: [String], default: [] },
+        null: { type: [String], default: [] },
+        absorb: { type: [String], default: [] },
+        reflect: { type: [String], default: [] },
+    },
+    { _id: false, minimize: false },
+);
+
+const abilitySchema = new mongoose.Schema(
+    {
+        STR: { type: Number, default: 0 },
+        DEX: { type: Number, default: 0 },
+        CON: { type: Number, default: 0 },
+        INT: { type: Number, default: 0 },
+        WIS: { type: Number, default: 0 },
+        CHA: { type: Number, default: 0 },
+    },
+    { _id: false, minimize: false },
+);
+
+const demonSchema = new mongoose.Schema(
+    {
+        slug: { type: String, required: true, unique: true, index: true },
+        name: { type: String, required: true, index: true },
+        arcana: { type: String, default: '' },
+        alignment: { type: String, default: '' },
+        level: { type: Number, default: 0 },
+        description: { type: String, default: '' },
+        image: { type: String, default: '' },
+        stats: { type: abilitySchema, default: () => ({}) },
+        mods: { type: abilitySchema, default: () => ({}) },
+        resistances: { type: resistanceSchema, default: () => ({}) },
+        skills: { type: [mongoose.Schema.Types.Mixed], default: [] },
+        tags: { type: [String], default: [] },
+        searchTerms: { type: [String], default: [] },
+        sourceId: { type: Number, index: true },
+    },
+    {
+        timestamps: true,
+        minimize: false,
+    },
+);
+
+demonSchema.index({ name: 'text', arcana: 'text', alignment: 'text', description: 'text', searchTerms: 'text' }, {
+    weights: { name: 5, arcana: 2, alignment: 2, description: 1, searchTerms: 3 },
+});
+
+demonSchema.index({ level: 1 });
+
+demonSchema.pre('save', function normalizeFields(next) {
+    if (typeof this.slug === 'string') {
+        this.slug = this.slug.trim().toLowerCase();
+    }
+    if (typeof this.name === 'string') {
+        this.name = this.name.trim();
+    }
+    next();
+});
+
+export default mongoose.models.Demon || mongoose.model('Demon', demonSchema);

--- a/models/Game.js
+++ b/models/Game.js
@@ -1,0 +1,19 @@
+import mongoose from '../lib/mongoose.js';
+
+const gameSchema = new mongoose.Schema(
+    {
+        id: { type: String, required: true, unique: true, index: true },
+        name: { type: String, required: true, default: 'Untitled Game' },
+        dmId: { type: String, required: true, index: true },
+    },
+    {
+        timestamps: true,
+        minimize: false,
+        strict: false,
+    },
+);
+
+gameSchema.index({ 'players.userId': 1 });
+gameSchema.index({ 'story.channelId': 1 });
+
+export default mongoose.models.Game || mongoose.model('Game', gameSchema);

--- a/models/User.js
+++ b/models/User.js
@@ -1,0 +1,15 @@
+import mongoose from '../lib/mongoose.js';
+
+const userSchema = new mongoose.Schema(
+    {
+        id: { type: String, required: true, unique: true, index: true },
+        username: { type: String, required: true, unique: true, index: true },
+        pass: { type: String, required: true },
+    },
+    {
+        timestamps: true,
+        minimize: false,
+    },
+);
+
+export default mongoose.models.User || mongoose.model('User', userSchema);

--- a/package.json
+++ b/package.json
@@ -9,16 +9,22 @@
     "lint": "eslint .",
     "preview": "vite preview --host --port 5173",
     "start": "node server.js",
-    "update:demons": "node scripts/convert-demons.js"
+    "update:demons": "node scripts/convert-demons.js",
+    "import:demons": "node scripts/import-demons.js",
+    "test:import": "node scripts/test-import-demons.js",
+    "bot:demon": "node bot/demonLookupBot.js",
+    "register:discord": "node scripts/register-discord-commands.js"
   },
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^4.19.2",
     "express-session": "^1.18.0",
+    "mongoose": "^8.8.0",
     "process": "^0.11.10",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
-    "uuid": "^9.0.1"
+    "uuid": "^9.0.1",
+    "ws": "^8.18.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",

--- a/routes/personas.routes.js
+++ b/routes/personas.routes.js
@@ -1,27 +1,18 @@
-﻿// --- FILE: routes/personas.routes.js ---
+// --- FILE: routes/personas.routes.js ---
 import { Router } from 'express';
-import fs from 'fs/promises';
-import path from 'path';
-import { fileURLToPath } from 'url';
+import {
+    searchDemons,
+    findDemonBySlug,
+    findClosestDemon,
+    summarizeDemon,
+} from '../services/demons.js';
 
-// Local persona data sourced from data/demons.json
 const r = Router();
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const DEMON_PATH = path.join(__dirname, '..', 'data', 'demons.json');
 const SEARCH_QUERY_REGEX = /^[\p{L}\p{N}\s'-]+$/u;
-const SLUG_REGEX = /^[a-z0-9-]+$/i;
+const MAX_LOOKUP_LENGTH = 64;
 
 function safeTrim(value) {
     return typeof value === 'string' ? value.trim() : String(value ?? '').trim();
-}
-
-let cache = null;
-async function loadDemons() {
-    if (!cache) {
-        const txt = await fs.readFile(DEMON_PATH, 'utf8');
-        cache = JSON.parse(txt);
-    }
-    return cache;
 }
 
 function parseSearchQuery(value) {
@@ -29,24 +20,37 @@ function parseSearchQuery(value) {
     if (!raw) {
         return { isEmpty: true };
     }
-    if (raw.length > 64) {
+    if (raw.length > MAX_LOOKUP_LENGTH) {
         return { error: 'invalid query length' };
     }
     if (!SEARCH_QUERY_REGEX.test(raw)) {
         return { error: 'invalid query format' };
     }
-    return { value: raw.toLowerCase() };
+    return { value: raw };
 }
 
-function normalizeSlug(value) {
+function normalizeLookupTerm(value) {
     const raw = safeTrim(value);
-    if (!raw || raw.length > 64) {
+    if (!raw || raw.length > MAX_LOOKUP_LENGTH) {
         return null;
     }
-    if (!SLUG_REGEX.test(raw)) {
-        return null;
-    }
-    return raw.toLowerCase();
+    return raw
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, '') || null;
+}
+
+function buildSearchResult(demon) {
+    if (!demon) return null;
+    return {
+        slug: demon.slug,
+        query: demon.slug,
+        name: demon.name,
+        arcana: demon.arcana || '',
+        alignment: demon.alignment || '',
+        level: demon.level ?? null,
+        image: demon.image || '',
+    };
 }
 
 // GET /api/personas/search?q=jack
@@ -57,16 +61,8 @@ r.get('/search', async (req, res) => {
         if (parsed?.error) {
             return res.status(400).json({ error: parsed.error });
         }
-        const q = parsed.value;
-        const demons = await loadDemons();
-        const hits = demons
-            .filter(d =>
-                d.name.toLowerCase().includes(q) ||
-                String(d.query || '').toLowerCase().includes(q)
-            )
-            .slice(0, 25)
-            .map(d => ({ slug: d.query, name: d.name }));
-        res.json(hits);
+        const hits = await searchDemons(parsed.value, { limit: 25 });
+        res.json(hits.map((hit) => buildSearchResult(hit)).filter(Boolean));
     } catch (e) {
         console.error('persona search failed', e);
         res.status(500).json({ error: 'search failed' });
@@ -76,14 +72,36 @@ r.get('/search', async (req, res) => {
 // GET /api/personas/:slug
 r.get('/:slug', async (req, res) => {
     try {
-        const slug = normalizeSlug(req.params.slug);
-        if (!slug) {
+        const rawInput = safeTrim(req.params.slug);
+        if (!rawInput) {
             return res.status(400).json({ error: 'invalid persona identifier' });
         }
-        const demons = await loadDemons();
-        const demon = demons.find(d => String(d.query ?? '').toLowerCase() === slug);
-        if (!demon) return res.status(404).json({ error: 'persona not found' });
-        res.json(demon);
+        const normalized = normalizeLookupTerm(rawInput);
+        let demon = null;
+        if (normalized) {
+            demon = await findDemonBySlug(normalized);
+        }
+        if (!demon) {
+            const [firstHit] = await searchDemons(rawInput, { limit: 1 });
+            if (firstHit) {
+                demon = firstHit;
+            }
+        }
+        if (!demon) {
+            const suggestion = await findClosestDemon(rawInput);
+            return res.status(404).json({
+                error: 'persona_not_found',
+                closeMatch: suggestion
+                    ? {
+                          slug: suggestion.slug,
+                          name: suggestion.name,
+                          distance: suggestion.distance,
+                          confidence: Number((1 - suggestion.ratio).toFixed(3)),
+                      }
+                    : null,
+            });
+        }
+        res.json(summarizeDemon(demon));
     } catch (e) {
         console.error('persona lookup failed', e);
         res.status(500).json({ error: 'lookup failed' });

--- a/scripts/import-demons.js
+++ b/scripts/import-demons.js
@@ -1,0 +1,188 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { loadEnv, envString } from '../config/env.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..');
+const demonsPath = path.join(repoRoot, 'data', 'demons.json');
+
+const ABILITY_KEYS = ['STR', 'DEX', 'CON', 'INT', 'WIS', 'CHA'];
+
+function slugify(value) {
+    return String(value || '')
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, '');
+}
+
+function normalizeAbilityBlock(source = {}) {
+    const block = {};
+    for (const key of ABILITY_KEYS) {
+        const raw = source?.[key];
+        const num = Number(raw);
+        block[key] = Number.isFinite(num) ? num : 0;
+    }
+    return block;
+}
+
+function uniqueStrings(values) {
+    const set = new Set();
+    const output = [];
+    for (const value of values) {
+        if (!value) continue;
+        const trimmed = String(value).trim();
+        if (!trimmed) continue;
+        const lower = trimmed.toLowerCase();
+        if (set.has(lower)) continue;
+        set.add(lower);
+        output.push(trimmed);
+    }
+    return output;
+}
+
+function buildSearchTerms(entry) {
+    const terms = [];
+    terms.push(entry.name);
+    terms.push(entry.arcana);
+    terms.push(entry.alignment);
+    if (Array.isArray(entry.tags)) {
+        terms.push(...entry.tags);
+    }
+    if (Array.isArray(entry.skills)) {
+        for (const skill of entry.skills) {
+            if (typeof skill === 'string') {
+                terms.push(skill);
+            } else if (skill?.name) {
+                terms.push(skill.name);
+            }
+        }
+    }
+    return uniqueStrings(
+        terms
+            .map((term) => String(term || '').toLowerCase())
+            .filter(Boolean),
+    );
+}
+
+function normalizeResistanceBlock(source = {}) {
+    return {
+        weak: uniqueStrings(source.weak || source.weaks || []),
+        resist: uniqueStrings(source.resist || source.resists || []),
+        null: uniqueStrings(source.null || source.nullify || []),
+        absorb: uniqueStrings(source.absorb || source.absorbs || []),
+        reflect: uniqueStrings(source.reflect || source.reflects || []),
+    };
+}
+
+function normalizeSkills(skills) {
+    if (!Array.isArray(skills)) return [];
+    return skills.map((skill) => {
+        if (typeof skill === 'string') {
+            return { name: skill };
+        }
+        if (!skill || typeof skill !== 'object') return null;
+        const name = String(skill.name || '').trim();
+        if (!name) return null;
+        const cost = skill.cost ?? skill.mp ?? skill.sp ?? null;
+        const element = skill.element || skill.type || null;
+        const description = skill.description || skill.desc || '';
+        return {
+            name,
+            cost: typeof cost === 'number' ? cost : null,
+            element: element ? String(element).trim() : null,
+            description: description ? String(description).trim() : '',
+        };
+    }).filter(Boolean);
+}
+
+function convertEntry(raw) {
+    const slug = slugify(raw.query || raw.slug || raw.name);
+    if (!slug) return null;
+    const levelRaw = Number(raw.level);
+    const level = Number.isFinite(levelRaw) ? levelRaw : null;
+    return {
+        slug,
+        name: String(raw.name || slug).trim(),
+        arcana: String(raw.arcana || '').trim(),
+        alignment: String(raw.alignment || '').trim(),
+        level,
+        description: String(raw.description || '').trim(),
+        image: String(raw.image || '').trim(),
+        stats: normalizeAbilityBlock(raw.stats || raw),
+        mods: normalizeAbilityBlock(raw.mods || {}),
+        resistances: normalizeResistanceBlock(raw.resistances || raw),
+        skills: normalizeSkills(raw.skills),
+        tags: uniqueStrings([raw.dlc ? `dlc:${raw.dlc}` : null, ...(Array.isArray(raw.tags) ? raw.tags : [])]),
+        searchTerms: buildSearchTerms(raw),
+        sourceId: Number.isFinite(Number(raw.id)) ? Number(raw.id) : null,
+    };
+}
+
+async function readSource(file = demonsPath) {
+    const content = await fs.readFile(file, 'utf8');
+    const parsed = JSON.parse(content);
+    if (!Array.isArray(parsed)) {
+        throw new Error('Expected data/demons.json to be an array.');
+    }
+    const converted = parsed
+        .map((entry) => convertEntry(entry))
+        .filter(Boolean);
+    return converted;
+}
+
+export async function importDemons({ file = demonsPath, dryRun = false, dropMissing = true } = {}) {
+    await loadEnv({ root: repoRoot });
+    const entries = await readSource(file);
+    if (dryRun) {
+        console.log(`[dry-run] Prepared ${entries.length} demons for import.`);
+        const sample = entries.slice(0, 3).map((entry) => ({ slug: entry.slug, name: entry.name, level: entry.level }));
+        console.log('[dry-run] Sample:', sample);
+        return { count: entries.length, entries: sample };
+    }
+
+    const mongooseModule = await import('../lib/mongoose.js');
+    const mongoose = mongooseModule.default ?? mongooseModule;
+    const DemonModule = await import('../models/Demon.js');
+    const Demon = DemonModule.default ?? DemonModule;
+
+    const uri = envString('MONGODB_URI');
+    const dbName = envString('MONGODB_DB_NAME');
+    if (!uri) {
+        throw new Error('MONGODB_URI is not configured.');
+    }
+
+    await mongoose.connect(uri, { dbName: dbName || undefined });
+
+    const bulkOps = entries.map((entry) => ({
+        replaceOne: {
+            filter: { slug: entry.slug },
+            replacement: entry,
+            upsert: true,
+        },
+    }));
+
+    if (bulkOps.length > 0) {
+        await Demon.bulkWrite(bulkOps, { ordered: false });
+    }
+
+    if (dropMissing) {
+        const slugs = entries.map((entry) => entry.slug);
+        await Demon.deleteMany({ slug: { $nin: slugs } });
+    }
+
+    await mongoose.disconnect();
+    console.log(`Imported ${entries.length} demons into MongoDB.`);
+    return { count: entries.length };
+}
+
+if (import.meta.url === process.argv[1] || import.meta.url === `file://${process.argv[1]}`) {
+    const args = new Set(process.argv.slice(2));
+    const dryRun = args.has('--dry-run');
+    const keep = args.has('--keep-missing');
+    importDemons({ dryRun, dropMissing: !keep })
+        .catch((err) => {
+            console.error('Failed to import demons:', err);
+            process.exit(1);
+        });
+}

--- a/scripts/register-discord-commands.js
+++ b/scripts/register-discord-commands.js
@@ -1,0 +1,64 @@
+import { loadEnv, envString } from '../config/env.js';
+
+const API_BASE = 'https://discord.com/api/v10';
+
+await loadEnv();
+
+const token = envString('DISCORD_PRIMARY_BOT_TOKEN')
+    || envString('DISCORD_DEFAULT_BOT_TOKEN')
+    || envString('DISCORD_BOT_TOKEN')
+    || envString('BOT_TOKEN');
+const applicationId = envString('DISCORD_APPLICATION_ID');
+const guildId = envString('DISCORD_COMMAND_GUILD_ID')
+    || envString('DISCORD_PRIMARY_GUILD_ID')
+    || envString('DISCORD_GUILD_ID');
+
+if (!token) {
+    console.error('Missing bot token. Set DISCORD_PRIMARY_BOT_TOKEN or DISCORD_BOT_TOKEN.');
+    process.exit(1);
+}
+if (!applicationId) {
+    console.error('Missing DISCORD_APPLICATION_ID environment variable.');
+    process.exit(1);
+}
+
+const command = {
+    name: 'lookup',
+    description: 'Look up codex information',
+    options: [
+        {
+            type: 1,
+            name: 'demon',
+            description: 'Look up a demon in the codex',
+            options: [
+                {
+                    type: 3,
+                    name: 'name',
+                    description: 'Name or slug of the demon',
+                    required: true,
+                },
+            ],
+        },
+    ],
+};
+
+const url = guildId
+    ? `${API_BASE}/applications/${applicationId}/guilds/${guildId}/commands`
+    : `${API_BASE}/applications/${applicationId}/commands`;
+
+const res = await fetch(url, {
+    method: 'PUT',
+    headers: {
+        Authorization: `Bot ${token}`,
+        'Content-Type': 'application/json',
+    },
+    body: JSON.stringify([command]),
+});
+
+if (!res.ok) {
+    const text = await res.text();
+    console.error('Failed to register slash command:', res.status, text);
+    process.exit(1);
+}
+
+console.log(`Registered /lookup demon command${guildId ? ` for guild ${guildId}` : ' globally'}.`);

--- a/scripts/test-import-demons.js
+++ b/scripts/test-import-demons.js
@@ -1,0 +1,11 @@
+import { importDemons } from './import-demons.js';
+
+(async () => {
+    try {
+        const result = await importDemons({ dryRun: true });
+        console.log(`Verified demon import mapping for ${result.count} entries.`);
+    } catch (err) {
+        console.error('Import verification failed:', err);
+        process.exit(1);
+    }
+})();

--- a/services/demons.js
+++ b/services/demons.js
@@ -1,0 +1,175 @@
+import Demon from '../models/Demon.js';
+
+function sanitizeDemonDoc(doc) {
+    if (!doc) return null;
+    const {
+        _id,
+        __v,
+        createdAt: _createdAt,
+        updatedAt: _updatedAt,
+        slug,
+        ...rest
+    } = doc;
+    return {
+        ...rest,
+        slug,
+        query: slug,
+    };
+}
+
+function escapeRegExp(str) {
+    return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function buildLooseRegex(query) {
+    if (!query) return null;
+    const tokens = query
+        .split(/\s+/)
+        .map((part) => escapeRegExp(part))
+        .filter(Boolean);
+    if (tokens.length === 0) return null;
+    return new RegExp(tokens.join('.*'), 'i');
+}
+
+function normalizeSearchTerm(value) {
+    if (typeof value !== 'string') return '';
+    return value.trim().slice(0, 64);
+}
+
+function normalizeComparisonTerm(value) {
+    if (typeof value !== 'string') return '';
+    return value.toLowerCase().replace(/[^a-z0-9]+/g, '');
+}
+
+function levenshtein(a, b) {
+    const lenA = a.length;
+    const lenB = b.length;
+    if (lenA === 0) return lenB;
+    if (lenB === 0) return lenA;
+
+    const prev = new Array(lenB + 1);
+    const curr = new Array(lenB + 1);
+    for (let j = 0; j <= lenB; j += 1) prev[j] = j;
+
+    for (let i = 1; i <= lenA; i += 1) {
+        curr[0] = i;
+        const charA = a[i - 1];
+        for (let j = 1; j <= lenB; j += 1) {
+            const charB = b[j - 1];
+            if (charA === charB) {
+                curr[j] = prev[j - 1];
+            } else {
+                curr[j] = Math.min(prev[j - 1], prev[j], curr[j - 1]) + 1;
+            }
+        }
+        for (let j = 0; j <= lenB; j += 1) {
+            prev[j] = curr[j];
+        }
+    }
+    return prev[lenB];
+}
+
+export async function searchDemons(term, { limit = 25 } = {}) {
+    const query = normalizeSearchTerm(term);
+    if (!query) return [];
+
+    const regex = buildLooseRegex(query);
+    const filters = regex
+        ? {
+            $or: [
+                { slug: regex },
+                { name: regex },
+                { arcana: regex },
+                { alignment: regex },
+                { tags: regex },
+                { searchTerms: regex },
+                { description: regex },
+                { skills: regex },
+            ],
+        }
+        : {};
+
+    const docs = await Demon.find(filters)
+        .sort({ level: 1, name: 1 })
+        .limit(Math.max(1, Math.min(100, limit)))
+        .lean();
+
+    return docs.map((doc) => sanitizeDemonDoc(doc));
+}
+
+export async function findDemonBySlug(slug) {
+    if (typeof slug !== 'string' || !slug.trim()) return null;
+    const normalized = slug.trim().toLowerCase();
+    const doc = await Demon.findOne({ slug: normalized }).lean();
+    return sanitizeDemonDoc(doc);
+}
+
+export async function findClosestDemon(term, { threshold = 0.45 } = {}) {
+    const normalized = normalizeComparisonTerm(term);
+    if (!normalized) return null;
+    const docs = await Demon.find({}, { slug: 1, name: 1, searchTerms: 1 })
+        .limit(1500)
+        .lean();
+    let best = null;
+    for (const doc of docs) {
+        const options = new Set([
+            doc.slug,
+            doc.name,
+            ...(Array.isArray(doc.searchTerms) ? doc.searchTerms : []),
+        ]);
+        for (const option of options) {
+            const normalizedOption = normalizeComparisonTerm(option);
+            if (!normalizedOption) continue;
+            const distance = levenshtein(normalized, normalizedOption);
+            const maxLen = Math.max(normalized.length, normalizedOption.length, 1);
+            const ratio = distance / maxLen;
+            if (ratio <= threshold) {
+                if (!best || ratio < best.ratio) {
+                    best = {
+                        ratio,
+                        distance,
+                        slug: doc.slug,
+                        name: doc.name,
+                    };
+                }
+            }
+        }
+    }
+    return best;
+}
+
+export function summarizeDemon(demon) {
+    if (!demon) return null;
+    const stats = demon.stats || {};
+    const resist = demon.resistances || {};
+    return {
+        name: demon.name,
+        arcana: demon.arcana || '',
+        alignment: demon.alignment || '',
+        level: demon.level ?? null,
+        description: demon.description || '',
+        image: demon.image || '',
+        stats,
+        mods: demon.mods || {},
+        resistances: {
+            weak: Array.isArray(resist.weak) ? resist.weak : [],
+            resist: Array.isArray(resist.resist) ? resist.resist : [],
+            null: Array.isArray(resist.null) ? resist.null : [],
+            absorb: Array.isArray(resist.absorb) ? resist.absorb : [],
+            reflect: Array.isArray(resist.reflect) ? resist.reflect : [],
+        },
+        skills: Array.isArray(demon.skills) ? demon.skills : [],
+        slug: demon.slug,
+        query: demon.slug,
+    };
+}
+
+export function buildDemonDetailString(demon) {
+    const parts = [];
+    if (demon.arcana) parts.push(`Arcana: ${demon.arcana}`);
+    if (demon.alignment) parts.push(`Alignment: ${demon.alignment}`);
+    if (Number.isFinite(demon.level)) parts.push(`Level ${demon.level}`);
+    if (parts.length === 0) return 'Uncatalogued demon';
+    return parts.join(' · ');
+}
+

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -1961,6 +1961,34 @@ label {
     gap: 4px;
 }
 
+.story-callout {
+    border: 1px dashed var(--border);
+    background: var(--surface-2);
+    padding: 16px;
+    border-radius: var(--radius);
+    display: grid;
+    gap: 12px;
+}
+
+.story-callout__grid {
+    display: grid;
+    gap: 8px;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+}
+
+.story-callout__label {
+    display: block;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--muted);
+    margin-bottom: 2px;
+}
+
+.story-callout code {
+    font-size: 0.85rem;
+}
+
 /* Character sheet layout */
 .sheet-card { display: grid; gap: 24px; }
 .sheet-header { display: flex; justify-content: space-between; align-items: flex-start; gap: 16px; }
@@ -2067,7 +2095,7 @@ label {
 .combat-skill-manager__filters label { display: grid; gap: 4px; }
 .combat-skill-manager__filters input,
 .combat-skill-manager__filters select { min-width: 160px; width: 100%; }
-.combat-skill-grid { display: grid; gap: 16px; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); }
+.combat-skill-grid { display: grid; gap: 16px; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); }
 .combat-skill-card { border: 1px solid var(--border); border-radius: var(--radius); padding: 16px; background: var(--surface-2); display: grid; gap: 12px; transition: border-color var(--trans-fast), box-shadow var(--trans-fast), transform var(--trans-fast); }
 .combat-skill-card:hover { border-color: color-mix(in oklab, var(--brand) 40%, var(--border) 60%); box-shadow: 0 8px 22px rgba(15,17,21,0.16); transform: translateY(-2px); }
 .combat-skill-card.is-editing { border-color: var(--brand); box-shadow: 0 12px 28px rgba(15,17,21,0.18); }
@@ -2099,24 +2127,196 @@ label {
 .demon-codex__filters { display: flex; flex-wrap: wrap; gap: 12px; margin-top: 16px; align-items: flex-end; }
 .demon-codex__filter { flex: 1 1 180px; min-width: 180px; }
 .demon-codex__clear { align-self: center; }
-.demon-codex__grid { margin-top: 16px; display: grid; gap: 16px; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); }
+.demon-codex__grid { margin-top: 16px; display: grid; gap: 16px; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); }
 .demon-codex__empty { margin-top: 16px; padding: 24px; border: 1px dashed var(--border); border-radius: var(--radius); text-align: center; }
 
-.demon-card { display: grid; gap: 12px; padding: 16px; }
-.demon-card__header { display: grid; grid-template-columns: auto 1fr auto; gap: 12px; align-items: flex-start; }
-.demon-card__image { width: 96px; height: 96px; object-fit: cover; border-radius: var(--radius-sm); border: 1px solid var(--border); background: #0b0c10; }
-.demon-card__title { display: grid; gap: 4px; }
-.demon-card__name { font-size: 1.05rem; }
-.demon-card__actions { display: flex; gap: 6px; flex-wrap: wrap; justify-content: flex-end; }
-.demon-card__stats { display: flex; flex-wrap: wrap; gap: 6px; }
-.demon-card__resists { display: grid; gap: 4px; }
-.demon-card__skills { display: grid; gap: 6px; align-items: flex-start; }
-.demon-card__skills-btn { justify-self: flex-start; }
-.demon-card__notes { opacity: 0.85; }
+.demon-card {
+    display: grid;
+    gap: 14px;
+    padding: 18px 20px;
+    border-radius: var(--radius);
+    border: 1px solid color-mix(in oklab, var(--border) 60%, transparent);
+    background: linear-gradient(135deg, color-mix(in oklab, var(--brand) 6%, transparent), color-mix(in oklab, var(--surface-2) 85%, transparent));
+    box-shadow: var(--shadow-sm);
+}
 
-@media (max-width: 640px) {
-    .demon-card__header { grid-template-columns: 1fr; }
-    .demon-card__actions { justify-content: flex-start; }
+.demon-card__top {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 16px;
+}
+
+.demon-card__identity {
+    display: grid;
+    gap: 6px;
+}
+
+.demon-card__name {
+    font-size: 1.2rem;
+    letter-spacing: 0.02em;
+}
+
+.demon-card__chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+
+.demon-card__chip {
+    display: inline-flex;
+    align-items: center;
+    border-radius: 999px;
+    padding: 4px 10px;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    background: color-mix(in oklab, var(--brand) 16%, transparent);
+    border: 1px solid color-mix(in oklab, var(--brand) 22%, transparent);
+}
+
+.demon-card__actions {
+    display: flex;
+    gap: 10px;
+    align-items: flex-end;
+}
+
+.demon-card__level {
+    font-size: 0.85rem;
+    font-weight: 600;
+    padding: 4px 10px;
+    border-radius: 999px;
+    background: color-mix(in oklab, var(--brand) 12%, transparent);
+}
+
+.demon-card__buttons {
+    display: flex;
+    gap: 6px;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+}
+
+.demon-card__description {
+    margin: 0;
+    color: var(--muted);
+    font-size: 0.9rem;
+}
+
+.demon-card__body {
+    display: grid;
+    grid-template-columns: minmax(0, auto) minmax(0, 1fr);
+    gap: 16px;
+    align-items: stretch;
+}
+
+.demon-card__portrait {
+    width: 120px;
+    height: 120px;
+    object-fit: cover;
+    border-radius: var(--radius);
+    border: 1px solid var(--border);
+    background: #0b0c10;
+}
+
+.demon-card__info {
+    display: grid;
+    gap: 12px;
+}
+
+.demon-card__stats-row {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));
+    gap: 8px;
+}
+
+.demon-card__stat {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 8px 10px;
+    border-radius: var(--radius-sm);
+    background: color-mix(in oklab, var(--surface-2) 70%, transparent);
+    border: 1px solid color-mix(in oklab, var(--border) 65%, transparent);
+    font-size: 0.9rem;
+}
+
+.demon-card__stat-key {
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    font-size: 0.75rem;
+}
+
+.demon-card__resist-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+    gap: 8px;
+    font-size: 0.85rem;
+}
+
+.demon-card__resist {
+    display: grid;
+    gap: 4px;
+    padding: 8px 10px;
+    border-radius: var(--radius-sm);
+    background: color-mix(in oklab, var(--brand) 10%, transparent);
+    border: 1px solid color-mix(in oklab, var(--brand) 18%, transparent);
+}
+
+.demon-card__resist-label {
+    font-size: 0.7rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: color-mix(in oklab, var(--brand) 70%, var(--text) 30%);
+}
+
+.demon-card__resist-values {
+    font-weight: 500;
+}
+
+.demon-card__skills {
+    display: grid;
+    gap: 6px;
+}
+
+.demon-card__section-label {
+    font-size: 0.75rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--muted);
+}
+
+.demon-card__skill-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+
+.demon-card__skill-chip {
+    display: inline-flex;
+    align-items: center;
+    padding: 6px 10px;
+    border-radius: 999px;
+    background: color-mix(in oklab, var(--surface-2) 80%, transparent);
+    border: 1px solid color-mix(in oklab, var(--border) 60%, transparent);
+    font-size: 0.82rem;
+}
+
+.demon-card__skills-btn {
+    justify-self: flex-start;
+}
+
+.demon-card__notes {
+    border-top: 1px solid color-mix(in oklab, var(--border) 70%, transparent);
+    padding-top: 8px;
+    color: var(--muted);
+    font-size: 0.85rem;
+}
+
+@media (max-width: 720px) {
+    .demon-card__body { grid-template-columns: 1fr; }
+    .demon-card__actions { align-items: flex-start; flex-direction: column; }
+    .demon-card__portrait { width: 100%; height: 200px; }
 }
 
 .demon-skill-overlay { position: fixed; inset: 0; background: rgba(12, 14, 20, 0.55); display: flex; align-items: center; justify-content: center; padding: 24px; z-index: 40; }


### PR DESCRIPTION
## Summary
- replace JSON persistence with a MongoDB + Mongoose stack and add importer, models, and services for demons, games, and users
- add Discord tooling including slash-command bot, command registrar, and shared bot configuration surfaced in the campaign story settings UI with close-match lookup handling
- refresh the frontend codex presentation, matrix rain, and README/.env guidance to match the new data and Discord workflows

## Testing
- npm run lint
- npm run test:import
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d19d8958f883319cad2e9f2a58b411