### PR TITLE
Add battle map background, shapes, and saved maps

### DIFF
--- a/server.js
+++ b/server.js
@@ -33,11 +33,21 @@ const MAX_ALERT_LENGTH = 500;
 const HEX_COLOR_REGEX = /^#(?:[0-9a-f]{3}|[0-9a-f]{6})$/i;
 const MAX_MAP_STROKES = 800;
 const MAX_MAP_POINTS_PER_STROKE = 600;
+const MAX_MAP_LIBRARY_ENTRIES = 24;
+const MAX_MAP_SHAPES = 80;
 const DEFAULT_STROKE_COLOR = '#f97316';
 const DEFAULT_PLAYER_TOKEN_COLOR = '#38bdf8';
 const DEFAULT_DEMON_TOKEN_COLOR = '#f97316';
 const DEFAULT_CUSTOM_TOKEN_COLOR = '#a855f7';
 const DEFAULT_ENEMY_TOKEN_COLOR = '#ef4444';
+const DEFAULT_SHAPE_FILL = '#1e293b';
+const DEFAULT_SHAPE_STROKE = '#f8fafc';
+const DEFAULT_SHAPE_STROKE_WIDTH = 2;
+const DEFAULT_SHAPE_OPACITY = 0.6;
+const DEFAULT_BACKGROUND_SCALE = 1;
+const DEFAULT_BACKGROUND_OPACITY = 1;
+const MAP_SHAPE_TYPES = new Set(['rectangle', 'circle', 'line']);
+const MIN_SHAPE_SIZE = 0.02;
 const DEFAULT_DB_PATH = path.join(__dirname, 'data', 'db.json');
 
 await loadEnv({ root: __dirname });
@@ -205,6 +215,346 @@ function clamp01(value) {
     return num;
 }
 
+function normalizeRotation(value) {
+    const num = Number(value);
+    if (!Number.isFinite(num)) return 0;
+    const normalized = num % 360;
+    return normalized < 0 ? normalized + 360 : normalized;
+}
+
+function defaultMapBackground() {
+    return {
+        url: '',
+        x: 0.5,
+        y: 0.5,
+        scale: DEFAULT_BACKGROUND_SCALE,
+        rotation: 0,
+        opacity: DEFAULT_BACKGROUND_OPACITY,
+    };
+}
+
+function normalizeMapBackground(entry) {
+    const defaults = defaultMapBackground();
+    if (!entry || typeof entry !== 'object') {
+        return { ...defaults };
+    }
+    const url = typeof entry.url === 'string' ? entry.url.trim() : '';
+    const xSource = Object.prototype.hasOwnProperty.call(entry, 'x') ? entry.x : defaults.x;
+    const ySource = Object.prototype.hasOwnProperty.call(entry, 'y') ? entry.y : defaults.y;
+    const x = clamp01(xSource);
+    const y = clamp01(ySource);
+    const scaleRaw = Number(entry.scale);
+    const scale = Number.isFinite(scaleRaw) ? Math.min(8, Math.max(0.2, scaleRaw)) : defaults.scale;
+    const rotation = normalizeRotation(entry.rotation);
+    const opacityRaw = Number(entry.opacity);
+    const opacity = Number.isFinite(opacityRaw) ? Math.min(1, Math.max(0.05, opacityRaw)) : defaults.opacity;
+    return { url, x, y, scale, rotation, opacity };
+}
+
+function presentMapBackground(background) {
+    return normalizeMapBackground(background);
+}
+
+function normalizeMapShape(entry) {
+    if (!entry || typeof entry !== 'object') return null;
+    const typeRaw = typeof entry.type === 'string' ? entry.type.trim().toLowerCase() : 'rectangle';
+    const type = MAP_SHAPE_TYPES.has(typeRaw) ? typeRaw : 'rectangle';
+    const id = typeof entry.id === 'string' && entry.id.trim() ? entry.id.trim() : uuid();
+    const createdAt = typeof entry.createdAt === 'string' ? entry.createdAt : new Date().toISOString();
+    const updatedAt = typeof entry.updatedAt === 'string' ? entry.updatedAt : createdAt;
+    const x = clamp01(Object.prototype.hasOwnProperty.call(entry, 'x') ? entry.x : 0.5);
+    const y = clamp01(Object.prototype.hasOwnProperty.call(entry, 'y') ? entry.y : 0.5);
+    const widthSource = Object.prototype.hasOwnProperty.call(entry, 'width') ? entry.width : 0.25;
+    const heightSource = Object.prototype.hasOwnProperty.call(entry, 'height') ? entry.height : widthSource;
+    let width = clamp01(widthSource);
+    let height = clamp01(heightSource);
+    if (!Number.isFinite(width) || width <= 0) width = 0.25;
+    if (!Number.isFinite(height) || height <= 0) height = type === 'line' ? MIN_SHAPE_SIZE : width;
+    width = Math.max(MIN_SHAPE_SIZE, Math.min(1, width));
+    height = Math.max(MIN_SHAPE_SIZE, Math.min(1, type === 'circle' ? width : height));
+    const rotation = normalizeRotation(entry.rotation);
+    const fill = sanitizeColor(entry.fill, type === 'line' ? DEFAULT_SHAPE_STROKE : DEFAULT_SHAPE_FILL);
+    const stroke = sanitizeColor(entry.stroke, DEFAULT_SHAPE_STROKE);
+    const strokeWidthRaw = Number(entry.strokeWidth);
+    const strokeWidth = Number.isFinite(strokeWidthRaw)
+        ? Math.min(20, Math.max(0, strokeWidthRaw))
+        : DEFAULT_SHAPE_STROKE_WIDTH;
+    const opacityRaw = Number(entry.opacity);
+    const opacity = Number.isFinite(opacityRaw)
+        ? Math.min(1, Math.max(0.05, opacityRaw))
+        : DEFAULT_SHAPE_OPACITY;
+    return {
+        id,
+        type,
+        x,
+        y,
+        width,
+        height: type === 'circle' ? width : height,
+        rotation,
+        fill,
+        stroke,
+        strokeWidth,
+        opacity,
+        createdAt,
+        updatedAt,
+    };
+}
+
+function presentMapShape(shape) {
+    if (!shape || typeof shape !== 'object') return null;
+    const normalized = normalizeMapShape(shape);
+    if (!normalized) return null;
+    return { ...normalized };
+}
+
+function findMapShape(map, shapeId) {
+    if (!map || !Array.isArray(map.shapes)) return null;
+    return map.shapes.find((shape) => shape && shape.id === shapeId) || null;
+}
+
+function applyMapShapeUpdate(shape, payload) {
+    if (!shape || !payload || typeof payload !== 'object') return false;
+    let changed = false;
+    if (Object.prototype.hasOwnProperty.call(payload, 'x')) {
+        const value = clamp01(payload.x);
+        if (shape.x !== value) {
+            shape.x = value;
+            changed = true;
+        }
+    }
+    if (Object.prototype.hasOwnProperty.call(payload, 'y')) {
+        const value = clamp01(payload.y);
+        if (shape.y !== value) {
+            shape.y = value;
+            changed = true;
+        }
+    }
+    if (Object.prototype.hasOwnProperty.call(payload, 'width')) {
+        const raw = clamp01(payload.width);
+        const value = Math.max(MIN_SHAPE_SIZE, Math.min(1, raw));
+        if (shape.width !== value) {
+            shape.width = value;
+            if (shape.type === 'circle') {
+                shape.height = value;
+            }
+            changed = true;
+        }
+    }
+    if (Object.prototype.hasOwnProperty.call(payload, 'height')) {
+        const raw = clamp01(payload.height);
+        const value = Math.max(MIN_SHAPE_SIZE, Math.min(1, raw));
+        if (shape.type === 'circle') {
+            if (shape.width !== value) {
+                shape.width = value;
+                shape.height = value;
+                changed = true;
+            }
+        } else if (shape.height !== value) {
+            shape.height = value;
+            changed = true;
+        }
+    }
+    if (Object.prototype.hasOwnProperty.call(payload, 'rotation')) {
+        const value = normalizeRotation(payload.rotation);
+        if (shape.rotation !== value) {
+            shape.rotation = value;
+            changed = true;
+        }
+    }
+    if (Object.prototype.hasOwnProperty.call(payload, 'fill')) {
+        const fallback = shape.type === 'line' ? shape.stroke : shape.fill || DEFAULT_SHAPE_FILL;
+        const value = sanitizeColor(payload.fill, fallback);
+        if (shape.fill !== value) {
+            shape.fill = value;
+            changed = true;
+        }
+    }
+    if (Object.prototype.hasOwnProperty.call(payload, 'stroke')) {
+        const value = sanitizeColor(payload.stroke, shape.stroke || DEFAULT_SHAPE_STROKE);
+        if (shape.stroke !== value) {
+            shape.stroke = value;
+            changed = true;
+        }
+    }
+    if (Object.prototype.hasOwnProperty.call(payload, 'strokeWidth')) {
+        const raw = Number(payload.strokeWidth);
+        const value = Number.isFinite(raw) ? Math.min(20, Math.max(0, raw)) : shape.strokeWidth;
+        if (shape.strokeWidth !== value) {
+            shape.strokeWidth = value;
+            changed = true;
+        }
+    }
+    if (Object.prototype.hasOwnProperty.call(payload, 'opacity')) {
+        const raw = Number(payload.opacity);
+        const value = Number.isFinite(raw) ? Math.min(1, Math.max(0.05, raw)) : shape.opacity;
+        if (shape.opacity !== value) {
+            shape.opacity = value;
+            changed = true;
+        }
+    }
+    return changed;
+}
+
+function applyBackgroundUpdate(map, payload) {
+    if (!map || !payload || typeof payload !== 'object') return false;
+    const target =
+        map.background && typeof map.background === 'object'
+            ? map.background
+            : (map.background = defaultMapBackground());
+    let changed = false;
+    if (Object.prototype.hasOwnProperty.call(payload, 'url')) {
+        const url = typeof payload.url === 'string' ? payload.url.trim() : '';
+        if (target.url !== url) {
+            target.url = url;
+            changed = true;
+        }
+    }
+    if (Object.prototype.hasOwnProperty.call(payload, 'x')) {
+        const value = clamp01(payload.x);
+        if (target.x !== value) {
+            target.x = value;
+            changed = true;
+        }
+    }
+    if (Object.prototype.hasOwnProperty.call(payload, 'y')) {
+        const value = clamp01(payload.y);
+        if (target.y !== value) {
+            target.y = value;
+            changed = true;
+        }
+    }
+    if (Object.prototype.hasOwnProperty.call(payload, 'scale')) {
+        const raw = Number(payload.scale);
+        const value = Number.isFinite(raw) ? Math.min(8, Math.max(0.2, raw)) : target.scale;
+        if (target.scale !== value) {
+            target.scale = value;
+            changed = true;
+        }
+    }
+    if (Object.prototype.hasOwnProperty.call(payload, 'rotation')) {
+        const value = normalizeRotation(payload.rotation);
+        if (target.rotation !== value) {
+            target.rotation = value;
+            changed = true;
+        }
+    }
+    if (Object.prototype.hasOwnProperty.call(payload, 'opacity')) {
+        const raw = Number(payload.opacity);
+        const value = Number.isFinite(raw) ? Math.min(1, Math.max(0.05, raw)) : target.opacity;
+        if (target.opacity !== value) {
+            target.opacity = value;
+            changed = true;
+        }
+    }
+    return changed;
+}
+
+function clearMapBackground(map) {
+    if (!map) return false;
+    map.background = defaultMapBackground();
+    map.background.url = '';
+    return true;
+}
+
+function captureMapSnapshot(game) {
+    const map = ensureMapState(game);
+    return {
+        strokes: map.strokes.map((stroke) => ({ ...stroke })),
+        tokens: map.tokens.map((token) => ({ ...token })),
+        shapes: map.shapes.map((shape) => ({ ...shape })),
+        background: { ...(map.background || defaultMapBackground()) },
+        settings: { ...(map.settings || {}) },
+    };
+}
+
+function normalizeMapSnapshot(snapshot, game) {
+    const tempGame = { ...game, map: snapshot };
+    const map = ensureMapState(tempGame);
+    return {
+        strokes: map.strokes.map((stroke) => ({ ...stroke })),
+        tokens: map.tokens.map((token) => ({ ...token })),
+        shapes: map.shapes.map((shape) => ({ ...shape })),
+        background: { ...(map.background || defaultMapBackground()) },
+        settings: { ...(map.settings || {}) },
+    };
+}
+
+function normalizeMapLibraryEntry(entry, game) {
+    if (!entry || typeof entry !== 'object') return null;
+    const id = typeof entry.id === 'string' && entry.id.trim() ? entry.id.trim() : uuid();
+    const name = sanitizeText(entry.name).trim() || 'Saved Battle Map';
+    const createdAt = typeof entry.createdAt === 'string' ? entry.createdAt : new Date().toISOString();
+    const updatedAt = typeof entry.updatedAt === 'string' ? entry.updatedAt : createdAt;
+    const snapshot = normalizeMapSnapshot(entry.snapshot || game?.map || {}, game);
+    const previewUrl =
+        typeof entry.previewUrl === 'string' && entry.previewUrl.trim()
+            ? entry.previewUrl.trim()
+            : snapshot.background?.url || '';
+    return { id, name, createdAt, updatedAt, snapshot, previewUrl };
+}
+
+function ensureMapLibrary(game) {
+    if (!game || typeof game !== 'object') return [];
+    if (!Array.isArray(game.mapLibrary)) {
+        game.mapLibrary = [];
+        return game.mapLibrary;
+    }
+    game.mapLibrary = game.mapLibrary
+        .map((entry) => normalizeMapLibraryEntry(entry, game))
+        .filter(Boolean);
+    if (game.mapLibrary.length > MAX_MAP_LIBRARY_ENTRIES) {
+        game.mapLibrary = game.mapLibrary
+            .sort((a, b) => {
+                const aKey = a.createdAt || '';
+                const bKey = b.createdAt || '';
+                return aKey.localeCompare(bKey);
+            })
+            .slice(game.mapLibrary.length - MAX_MAP_LIBRARY_ENTRIES);
+    }
+    return game.mapLibrary;
+}
+
+function presentMapLibraryEntry(entry) {
+    if (!entry || typeof entry !== 'object') return null;
+    return {
+        id: entry.id,
+        name: entry.name,
+        createdAt: entry.createdAt || null,
+        updatedAt: entry.updatedAt || entry.createdAt || null,
+        previewUrl: entry.previewUrl || '',
+    };
+}
+
+function presentMapLibrary(library) {
+    if (!Array.isArray(library)) return [];
+    return library
+        .slice()
+        .sort((a, b) => {
+            const aKey = a.updatedAt || a.createdAt || '';
+            const bKey = b.updatedAt || b.createdAt || '';
+            return bKey.localeCompare(aKey);
+        })
+        .map((entry) => presentMapLibraryEntry(entry))
+        .filter(Boolean);
+}
+
+function applyMapSnapshot(game, snapshot) {
+    if (!game) return null;
+    const current = ensureMapState(game);
+    const normalized = normalizeMapSnapshot(snapshot, game);
+    const timestamp = new Date().toISOString();
+    game.map = {
+        strokes: normalized.strokes,
+        tokens: normalized.tokens,
+        shapes: normalized.shapes,
+        background: normalized.background,
+        settings: { ...(normalized.settings || {}) },
+        paused: current.paused,
+        updatedAt: timestamp,
+    };
+    return game.map;
+}
+
 function sanitizeColor(value, fallback) {
     if (typeof value !== 'string') return fallback;
     const trimmed = value.trim();
@@ -367,8 +717,10 @@ function ensureMapState(game) {
         return {
             strokes: [],
             tokens: [],
+            shapes: [],
             settings: { allowPlayerDrawing: false, allowPlayerTokenMoves: false },
             paused: false,
+            background: defaultMapBackground(),
             updatedAt: new Date().toISOString(),
         };
     }
@@ -383,15 +735,23 @@ function ensureMapState(game) {
     const tokens = Array.isArray(raw.tokens)
         ? raw.tokens.map((token) => normalizeMapToken(token, game)).filter(Boolean)
         : [];
+    let shapes = Array.isArray(raw.shapes)
+        ? raw.shapes.map((shape) => normalizeMapShape(shape)).filter(Boolean)
+        : [];
+    if (shapes.length > MAX_MAP_SHAPES) {
+        shapes = shapes.slice(-MAX_MAP_SHAPES);
+    }
     const updatedAt = typeof raw.updatedAt === 'string' ? raw.updatedAt : new Date().toISOString();
     const mapState = {
         strokes,
         tokens,
+        shapes,
         settings: {
             allowPlayerDrawing: !!settingsRaw.allowPlayerDrawing,
             allowPlayerTokenMoves: !!settingsRaw.allowPlayerTokenMoves,
         },
         paused: !!raw.paused,
+        background: presentMapBackground(raw.background),
         updatedAt,
     };
     game.map = mapState;
@@ -403,8 +763,10 @@ function presentMapState(map) {
         return {
             strokes: [],
             tokens: [],
+            shapes: [],
             settings: { allowPlayerDrawing: false, allowPlayerTokenMoves: false },
             paused: false,
+            background: defaultMapBackground(),
             updatedAt: null,
         };
     }
@@ -414,14 +776,19 @@ function presentMapState(map) {
     const tokens = Array.isArray(map.tokens)
         ? map.tokens.map((token) => presentMapToken(token)).filter(Boolean)
         : [];
+    const shapes = Array.isArray(map.shapes)
+        ? map.shapes.map((shape) => presentMapShape(shape)).filter(Boolean)
+        : [];
     return {
         strokes,
         tokens,
+        shapes,
         settings: {
             allowPlayerDrawing: !!map.settings?.allowPlayerDrawing,
             allowPlayerTokenMoves: !!map.settings?.allowPlayerTokenMoves,
         },
         paused: !!map.paused,
+        background: presentMapBackground(map.background),
         updatedAt: typeof map.updatedAt === 'string' ? map.updatedAt : null,
     };
 }
@@ -520,6 +887,7 @@ function ensureGameShape(game) {
     game.combatSkills = ensureCombatSkills(game);
     game.media = ensureMediaState(game);
     game.map = ensureMapState(game);
+    game.mapLibrary = ensureMapLibrary(game);
     return game;
 }
 
@@ -545,6 +913,7 @@ function presentGame(game, { includeSecrets = false } = {}) {
         combatSkills,
         media: presentMediaState(normalized.media),
         map: presentMapState(normalized.map),
+        ...(includeSecrets ? { mapLibrary: presentMapLibrary(normalized.mapLibrary) } : {}),
     };
 }
 
@@ -2629,10 +2998,13 @@ app.post('/api/games', requireAuth, async (req, res) => {
         map: {
             strokes: [],
             tokens: [],
+            shapes: [],
             settings: { allowPlayerDrawing: false, allowPlayerTokenMoves: false },
             paused: false,
+            background: defaultMapBackground(),
             updatedAt: new Date().toISOString(),
         },
+        mapLibrary: [],
     };
     ensureWorldSkills(game);
     ensureMapState(game);
@@ -2929,6 +3301,162 @@ app.post('/api/games/:id/map/strokes/clear', requireAuth, async (req, res) => {
     res.json({ ok: true });
 });
 
+app.post('/api/games/:id/map/shapes', requireAuth, async (req, res) => {
+    const { id } = req.params || {};
+    const db = await readDB();
+    const game = getGame(db, id);
+    if (!game || !isMember(game, req.session.userId)) {
+        return res.status(404).json({ error: 'not_found' });
+    }
+    if (!isDM(game, req.session.userId)) {
+        return res.status(403).json({ error: 'forbidden' });
+    }
+
+    const map = ensureMapState(game);
+    const payload = req.body?.shape || req.body || {};
+    const shape = normalizeMapShape(payload);
+    if (!shape) {
+        return res.status(400).json({ error: 'invalid_shape' });
+    }
+
+    const timestamp = new Date().toISOString();
+    shape.createdAt = timestamp;
+    shape.updatedAt = timestamp;
+    map.shapes.push(shape);
+    if (map.shapes.length > MAX_MAP_SHAPES) {
+        map.shapes = map.shapes.slice(-MAX_MAP_SHAPES);
+    }
+    map.updatedAt = timestamp;
+
+    await persistGame(db, game, {
+        reason: 'map:shape:add',
+        actorId: req.session.userId,
+        broadcast: !map.paused,
+    });
+
+    res.status(201).json(presentMapShape(shape));
+});
+
+app.put('/api/games/:id/map/shapes/:shapeId', requireAuth, async (req, res) => {
+    const { id, shapeId } = req.params || {};
+    const db = await readDB();
+    const game = getGame(db, id);
+    if (!game || !isMember(game, req.session.userId)) {
+        return res.status(404).json({ error: 'not_found' });
+    }
+    if (!isDM(game, req.session.userId)) {
+        return res.status(403).json({ error: 'forbidden' });
+    }
+
+    const map = ensureMapState(game);
+    const shape = findMapShape(map, shapeId);
+    if (!shape) {
+        return res.status(404).json({ error: 'shape_not_found' });
+    }
+
+    const payload = req.body || {};
+    const changed = applyMapShapeUpdate(shape, payload);
+    if (!changed) {
+        return res.json(presentMapShape(shape));
+    }
+
+    const timestamp = new Date().toISOString();
+    shape.updatedAt = timestamp;
+    map.updatedAt = timestamp;
+
+    await persistGame(db, game, {
+        reason: 'map:shape:update',
+        actorId: req.session.userId,
+        broadcast: !map.paused,
+    });
+
+    res.json(presentMapShape(shape));
+});
+
+app.delete('/api/games/:id/map/shapes/:shapeId', requireAuth, async (req, res) => {
+    const { id, shapeId } = req.params || {};
+    const db = await readDB();
+    const game = getGame(db, id);
+    if (!game || !isMember(game, req.session.userId)) {
+        return res.status(404).json({ error: 'not_found' });
+    }
+    if (!isDM(game, req.session.userId)) {
+        return res.status(403).json({ error: 'forbidden' });
+    }
+
+    const map = ensureMapState(game);
+    const before = map.shapes.length;
+    map.shapes = map.shapes.filter((shape) => shape && shape.id !== shapeId);
+    if (before === map.shapes.length) {
+        return res.status(404).json({ error: 'shape_not_found' });
+    }
+
+    map.updatedAt = new Date().toISOString();
+
+    await persistGame(db, game, {
+        reason: 'map:shape:remove',
+        actorId: req.session.userId,
+        broadcast: !map.paused,
+    });
+
+    res.json({ ok: true });
+});
+
+app.put('/api/games/:id/map/background', requireAuth, async (req, res) => {
+    const { id } = req.params || {};
+    const db = await readDB();
+    const game = getGame(db, id);
+    if (!game || !isMember(game, req.session.userId)) {
+        return res.status(404).json({ error: 'not_found' });
+    }
+    if (!isDM(game, req.session.userId)) {
+        return res.status(403).json({ error: 'forbidden' });
+    }
+
+    const map = ensureMapState(game);
+    const changed = applyBackgroundUpdate(map, req.body || {});
+    if (!changed) {
+        return res.json(presentMapBackground(map.background));
+    }
+
+    map.updatedAt = new Date().toISOString();
+
+    await persistGame(db, game, {
+        reason: 'map:background',
+        actorId: req.session.userId,
+        broadcast: !map.paused,
+    });
+
+    res.json(presentMapBackground(map.background));
+});
+
+app.delete('/api/games/:id/map/background', requireAuth, async (req, res) => {
+    const { id } = req.params || {};
+    const db = await readDB();
+    const game = getGame(db, id);
+    if (!game || !isMember(game, req.session.userId)) {
+        return res.status(404).json({ error: 'not_found' });
+    }
+    if (!isDM(game, req.session.userId)) {
+        return res.status(403).json({ error: 'forbidden' });
+    }
+
+    const map = ensureMapState(game);
+    const changed = clearMapBackground(map);
+    if (!changed) {
+        return res.json({ ok: true, background: presentMapBackground(map.background) });
+    }
+    map.updatedAt = new Date().toISOString();
+
+    await persistGame(db, game, {
+        reason: 'map:background:clear',
+        actorId: req.session.userId,
+        broadcast: !map.paused,
+    });
+
+    res.json({ ok: true, background: presentMapBackground(map.background) });
+});
+
 app.post('/api/games/:id/map/tokens', requireAuth, async (req, res) => {
     const { id } = req.params || {};
     const db = await readDB();
@@ -3078,6 +3606,105 @@ app.delete('/api/games/:id/map/tokens/:tokenId', requireAuth, async (req, res) =
         broadcast: !map.paused,
     });
     res.json({ ok: true });
+});
+
+app.get('/api/games/:id/map/library', requireAuth, async (req, res) => {
+    const { id } = req.params || {};
+    const db = await readDB();
+    const game = getGame(db, id);
+    if (!game || !isMember(game, req.session.userId)) {
+        return res.status(404).json({ error: 'not_found' });
+    }
+    if (!isDM(game, req.session.userId)) {
+        return res.status(403).json({ error: 'forbidden' });
+    }
+
+    const library = ensureMapLibrary(game);
+    res.json({ maps: presentMapLibrary(library) });
+});
+
+app.post('/api/games/:id/map/library', requireAuth, async (req, res) => {
+    const { id } = req.params || {};
+    const db = await readDB();
+    const game = getGame(db, id);
+    if (!game || !isMember(game, req.session.userId)) {
+        return res.status(404).json({ error: 'not_found' });
+    }
+    if (!isDM(game, req.session.userId)) {
+        return res.status(403).json({ error: 'forbidden' });
+    }
+
+    const library = ensureMapLibrary(game);
+    const nameInput = sanitizeText(req.body?.name).trim();
+    const entryName = nameInput || `Battle Map ${library.length + 1}`;
+    const timestamp = new Date().toISOString();
+    const snapshot = captureMapSnapshot(game);
+    const entry = {
+        id: uuid(),
+        name: entryName.slice(0, 80),
+        createdAt: timestamp,
+        updatedAt: timestamp,
+        snapshot,
+        previewUrl: snapshot.background?.url || '',
+    };
+    library.push(entry);
+    ensureMapLibrary(game);
+
+    await persistGame(db, game, { broadcast: false });
+
+    res.status(201).json({ entry: presentMapLibraryEntry(entry), maps: presentMapLibrary(game.mapLibrary) });
+});
+
+app.delete('/api/games/:id/map/library/:entryId', requireAuth, async (req, res) => {
+    const { id, entryId } = req.params || {};
+    const db = await readDB();
+    const game = getGame(db, id);
+    if (!game || !isMember(game, req.session.userId)) {
+        return res.status(404).json({ error: 'not_found' });
+    }
+    if (!isDM(game, req.session.userId)) {
+        return res.status(403).json({ error: 'forbidden' });
+    }
+
+    const library = ensureMapLibrary(game);
+    const before = library.length;
+    game.mapLibrary = library.filter((entry) => entry && entry.id !== entryId);
+    if (before === game.mapLibrary.length) {
+        return res.status(404).json({ error: 'map_not_found' });
+    }
+
+    await persistGame(db, game, { broadcast: false });
+
+    res.json({ maps: presentMapLibrary(game.mapLibrary) });
+});
+
+app.post('/api/games/:id/map/library/:entryId/load', requireAuth, async (req, res) => {
+    const { id, entryId } = req.params || {};
+    const db = await readDB();
+    const game = getGame(db, id);
+    if (!game || !isMember(game, req.session.userId)) {
+        return res.status(404).json({ error: 'not_found' });
+    }
+    if (!isDM(game, req.session.userId)) {
+        return res.status(403).json({ error: 'forbidden' });
+    }
+
+    const library = ensureMapLibrary(game);
+    const entry = library.find((item) => item && item.id === entryId);
+    if (!entry) {
+        return res.status(404).json({ error: 'map_not_found' });
+    }
+
+    const map = applyMapSnapshot(game, entry.snapshot);
+    entry.updatedAt = new Date().toISOString();
+
+    await persistGame(db, game, {
+        reason: 'map:library:load',
+        actorId: req.session.userId,
+        broadcast: true,
+    });
+
+    res.json({ map: presentMapState(map), entry: presentMapLibraryEntry(entry), maps: presentMapLibrary(game.mapLibrary) });
 });
 
 // --- World skills ---

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -2487,12 +2487,29 @@ const MAP_DEFAULT_SETTINGS = Object.freeze({
 const MAP_BRUSH_COLORS = ['#f97316', '#38bdf8', '#a855f7', '#22c55e', '#f472b6'];
 const MAP_ENEMY_DEFAULT_COLOR = '#ef4444';
 const MAP_MAX_POINTS_PER_STROKE = 600;
+const MAP_DEFAULT_BACKGROUND = Object.freeze({
+    url: '',
+    x: 0.5,
+    y: 0.5,
+    scale: 1,
+    rotation: 0,
+    opacity: 1,
+});
+const MAP_SHAPE_TYPES = ['rectangle', 'circle', 'line'];
 
 function mapClamp01(value) {
     const num = Number(value);
     if (!Number.isFinite(num)) return 0;
     if (num <= 0) return 0;
     if (num >= 1) return 1;
+    return num;
+}
+
+function clamp(value, min, max, fallback = min) {
+    const num = Number(value);
+    if (!Number.isFinite(num)) return fallback;
+    if (num <= min) return min;
+    if (num >= max) return max;
     return num;
 }
 
@@ -2562,13 +2579,67 @@ function normalizeClientMapToken(token) {
     };
 }
 
+function normalizeClientMapShape(shape) {
+    if (!shape || typeof shape !== 'object') return null;
+    const typeRaw = typeof shape.type === 'string' ? shape.type.toLowerCase() : 'rectangle';
+    const type = MAP_SHAPE_TYPES.includes(typeRaw) ? typeRaw : 'rectangle';
+    const id = typeof shape.id === 'string' && shape.id ? shape.id : `shape-${Math.random().toString(36).slice(2, 10)}`;
+    const x = mapClamp01(Object.prototype.hasOwnProperty.call(shape, 'x') ? shape.x : 0.5);
+    const y = mapClamp01(Object.prototype.hasOwnProperty.call(shape, 'y') ? shape.y : 0.5);
+    const width = clamp(shape.width, 0.02, 1, 0.25);
+    const height = type === 'circle' ? width : clamp(shape.height, 0.02, 1, width);
+    const rotationRaw = Number(shape.rotation);
+    const rotation = Number.isFinite(rotationRaw) ? ((rotationRaw % 360) + 360) % 360 : 0;
+    const fill = typeof shape.fill === 'string' && shape.fill ? shape.fill : '#1e293b';
+    const stroke = typeof shape.stroke === 'string' && shape.stroke ? shape.stroke : '#f8fafc';
+    const strokeWidth = clamp(shape.strokeWidth, 0, 20, 2);
+    const opacity = clamp(shape.opacity, 0.05, 1, 0.6);
+    const createdAt = typeof shape.createdAt === 'string' ? shape.createdAt : null;
+    const updatedAt = typeof shape.updatedAt === 'string' ? shape.updatedAt : createdAt;
+    return { id, type, x, y, width, height, rotation, fill, stroke, strokeWidth, opacity, createdAt, updatedAt };
+}
+
+function normalizeClientMapBackground(background) {
+    if (!background || typeof background !== 'object') {
+        return { ...MAP_DEFAULT_BACKGROUND };
+    }
+    const url = typeof background.url === 'string' ? background.url.trim() : '';
+    const xSource = Object.prototype.hasOwnProperty.call(background, 'x') ? background.x : MAP_DEFAULT_BACKGROUND.x;
+    const ySource = Object.prototype.hasOwnProperty.call(background, 'y') ? background.y : MAP_DEFAULT_BACKGROUND.y;
+    const x = mapClamp01(xSource);
+    const y = mapClamp01(ySource);
+    const scale = clamp(background.scale, 0.2, 8, MAP_DEFAULT_BACKGROUND.scale);
+    const rotationRaw = Number(background.rotation);
+    const rotation = Number.isFinite(rotationRaw) ? ((rotationRaw % 360) + 360) % 360 : MAP_DEFAULT_BACKGROUND.rotation;
+    const opacity = clamp(background.opacity, 0.05, 1, MAP_DEFAULT_BACKGROUND.opacity);
+    return { url, x, y, scale, rotation, opacity };
+}
+
+function normalizeMapLibraryEntry(entry) {
+    if (!entry || typeof entry !== 'object') return null;
+    const id = typeof entry.id === 'string' && entry.id ? entry.id : null;
+    if (!id) return null;
+    const name = typeof entry.name === 'string' && entry.name.trim() ? entry.name.trim() : 'Saved map';
+    const createdAt = typeof entry.createdAt === 'string' ? entry.createdAt : null;
+    const updatedAt = typeof entry.updatedAt === 'string' ? entry.updatedAt : createdAt;
+    const previewUrl = typeof entry.previewUrl === 'string' ? entry.previewUrl : '';
+    return { id, name, createdAt, updatedAt, previewUrl };
+}
+
+function normalizeMapLibrary(list) {
+    if (!Array.isArray(list)) return [];
+    return list.map((entry) => normalizeMapLibraryEntry(entry)).filter(Boolean);
+}
+
 function normalizeClientMapState(map) {
     if (!map || typeof map !== 'object') {
         return {
             strokes: [],
             tokens: [],
+            shapes: [],
             settings: { ...MAP_DEFAULT_SETTINGS },
             paused: false,
+            background: { ...MAP_DEFAULT_BACKGROUND },
             updatedAt: null,
         };
     }
@@ -2578,14 +2649,19 @@ function normalizeClientMapState(map) {
     const tokens = Array.isArray(map.tokens)
         ? map.tokens.map((token) => normalizeClientMapToken(token)).filter(Boolean)
         : [];
+    const shapes = Array.isArray(map.shapes)
+        ? map.shapes.map((shape) => normalizeClientMapShape(shape)).filter(Boolean)
+        : [];
     return {
         strokes,
         tokens,
+        shapes,
         settings: {
             allowPlayerDrawing: !!map.settings?.allowPlayerDrawing,
             allowPlayerTokenMoves: !!map.settings?.allowPlayerTokenMoves,
         },
         paused: !!map.paused,
+        background: normalizeClientMapBackground(map.background),
         updatedAt: typeof map.updatedAt === 'string' ? map.updatedAt : null,
     };
 }
@@ -2628,9 +2704,31 @@ function describeDemonTooltip(demon) {
 function MapTab({ game, me }) {
     const isDM = game.dmId === me.id;
     const [mapState, setMapState] = useState(() => normalizeClientMapState(game?.map));
+    const [mapLibrary, setMapLibrary] = useState(() => normalizeMapLibrary(game?.mapLibrary));
+    const [backgroundDraft, setBackgroundDraft] = useState(() => mapState.background);
+    const backgroundDraftRef = useRef(mapState.background);
+    const latestBackgroundRef = useRef(mapState.background);
+    const backgroundUpdateTimerRef = useRef(null);
     useEffect(() => {
         setMapState(normalizeClientMapState(game?.map));
     }, [game.id, game?.map]);
+    useEffect(() => {
+        setMapLibrary(normalizeMapLibrary(game?.mapLibrary));
+    }, [game.id, game?.mapLibrary]);
+    useEffect(() => {
+        setBackgroundDraft(mapState.background);
+    }, [mapState.background]);
+    useEffect(() => {
+        backgroundDraftRef.current = backgroundDraft;
+    }, [backgroundDraft]);
+    useEffect(() => {
+        latestBackgroundRef.current = mapState.background;
+    }, [mapState.background]);
+    useEffect(() => () => {
+        if (backgroundUpdateTimerRef.current) {
+            window.clearTimeout(backgroundUpdateTimerRef.current);
+        }
+    }, []);
 
     useEffect(() => {
         if (typeof window === 'undefined') return () => {};
@@ -2650,6 +2748,10 @@ function MapTab({ game, me }) {
                     if (prev.updatedAt !== normalized.updatedAt) return normalized;
                     if (prev.tokens.length !== normalized.tokens.length) return normalized;
                     if (prev.strokes.length !== normalized.strokes.length) return normalized;
+                    if (prev.shapes.length !== normalized.shapes.length) return normalized;
+                    const prevBg = prev.background?.url || '';
+                    const nextBg = normalized.background?.url || '';
+                    if (prevBg !== nextBg) return normalized;
                     return prev;
                 });
             } catch (err) {
@@ -2669,6 +2771,34 @@ function MapTab({ game, me }) {
             }
         };
     }, [game?.id]);
+
+    const refreshMapLibrary = useCallback(async () => {
+        if (!isDM) return;
+        try {
+            const maps = await Games.listMapLibrary(game.id);
+            setMapLibrary(normalizeMapLibrary(maps));
+        } catch (err) {
+            console.warn('Failed to load battle map library', err);
+        }
+    }, [game.id, isDM]);
+
+    useEffect(() => {
+        if (!isDM) return () => {};
+        let cancelled = false;
+        (async () => {
+            try {
+                const maps = await Games.listMapLibrary(game.id);
+                if (!cancelled) {
+                    setMapLibrary(normalizeMapLibrary(maps));
+                }
+            } catch (err) {
+                console.warn('Failed to load battle map library', err);
+            }
+        })();
+        return () => {
+            cancelled = true;
+        };
+    }, [game.id, isDM]);
 
     const [tool, setTool] = useState('select');
     const [brushColor, setBrushColor] = useState(MAP_BRUSH_COLORS[0]);
@@ -2693,6 +2823,8 @@ function MapTab({ game, me }) {
     useEffect(() => {
         if (!isDM && tool === 'draw' && (!mapState.settings.allowPlayerDrawing || mapState.paused)) {
             setTool('select');
+        } else if (!isDM && tool === 'background') {
+            setTool('select');
         }
     }, [isDM, mapState.paused, mapState.settings.allowPlayerDrawing, tool]);
 
@@ -2716,7 +2848,17 @@ function MapTab({ game, me }) {
 
     const canDraw = isDM || (!mapState.paused && mapState.settings.allowPlayerDrawing);
     const canPaint = canDraw && tool === 'draw';
-    const tokenLayerPointerEvents = canPaint ? 'none' : 'auto';
+    const isBackgroundTool = tool === 'background';
+    const tokenLayerPointerEvents = canPaint || isBackgroundTool ? 'none' : 'auto';
+    const shapeLayerPointerEvents = canPaint || isBackgroundTool ? 'none' : 'auto';
+    const canvasPointerEvents = isBackgroundTool ? 'none' : 'auto';
+    const backgroundDisplay = useMemo(() => {
+        const base = mapState.background || MAP_DEFAULT_BACKGROUND;
+        if (dragPreview && dragPreview.kind === 'background') {
+            return { ...base, x: dragPreview.x, y: dragPreview.y };
+        }
+        return base;
+    }, [dragPreview, mapState.background]);
 
     const playerMap = useMemo(() => {
         const map = new Map();
@@ -2802,6 +2944,127 @@ function MapTab({ game, me }) {
             return { x: mapClamp01(x), y: mapClamp01(y) };
         },
         []
+    );
+
+    const handleUpdateBackground = useCallback(
+        async (patch) => {
+            if (!isDM) return;
+            try {
+                const response = await Games.updateMapBackground(game.id, patch);
+                const normalized = normalizeClientMapBackground(response);
+                setMapState((prev) => ({
+                    ...prev,
+                    background: normalized,
+                    updatedAt: new Date().toISOString(),
+                }));
+                setBackgroundDraft(normalized);
+            } catch (err) {
+                alert(err.message);
+            }
+        },
+        [game.id, isDM]
+    );
+
+    const queueBackgroundUpdate = useCallback(
+        (updates) => {
+            setBackgroundDraft((prev) => ({ ...prev, ...updates }));
+            if (backgroundUpdateTimerRef.current) {
+                window.clearTimeout(backgroundUpdateTimerRef.current);
+            }
+            backgroundUpdateTimerRef.current = window.setTimeout(() => {
+                const base = latestBackgroundRef.current || MAP_DEFAULT_BACKGROUND;
+                const target = backgroundDraftRef.current || base;
+                const patch = {};
+                if ((target.url || '') !== (base.url || '')) patch.url = target.url;
+                if (Math.abs(target.x - base.x) > 0.0005) patch.x = target.x;
+                if (Math.abs(target.y - base.y) > 0.0005) patch.y = target.y;
+                if (Math.abs(target.scale - base.scale) > 0.001) patch.scale = target.scale;
+                if (Math.abs(target.rotation - base.rotation) > 0.5) patch.rotation = target.rotation;
+                if (Math.abs(target.opacity - base.opacity) > 0.01) patch.opacity = target.opacity;
+                if (Object.keys(patch).length === 0) return;
+                handleUpdateBackground(patch);
+            }, 200);
+        },
+        [handleUpdateBackground]
+    );
+
+    const handleClearBackground = useCallback(async () => {
+        if (!isDM) return;
+        try {
+            const response = await Games.clearMapBackground(game.id);
+            const normalized = response?.background
+                ? normalizeClientMapBackground(response.background)
+                : { ...MAP_DEFAULT_BACKGROUND };
+            setMapState((prev) => ({
+                ...prev,
+                background: normalized,
+                updatedAt: new Date().toISOString(),
+            }));
+            setBackgroundDraft(normalized);
+        } catch (err) {
+            alert(err.message);
+        }
+    }, [game.id, isDM]);
+
+    const handleBackgroundPointerDown = useCallback(
+        (event) => {
+            if (!isDM || !isBackgroundTool) return;
+            event.preventDefault();
+            const { x, y } = getPointerPosition(event);
+            const base = mapState.background || MAP_DEFAULT_BACKGROUND;
+            const offsetX = x - base.x;
+            const offsetY = y - base.y;
+            const target = event.currentTarget;
+            if (target?.setPointerCapture) {
+                try {
+                    target.setPointerCapture(event.pointerId);
+                } catch {
+                    // ignore capture errors
+                }
+            }
+            setDragging({ kind: 'background', pointerId: event.pointerId, offsetX, offsetY });
+            setDragPreview({ kind: 'background', x: mapClamp01(x - offsetX), y: mapClamp01(y - offsetY) });
+        },
+        [getPointerPosition, isBackgroundTool, isDM, mapState.background]
+    );
+
+    const handleBackgroundPointerMove = useCallback(
+        (event) => {
+            if (!dragging || dragging.kind !== 'background') return;
+            const { x, y } = getPointerPosition(event);
+            setDragPreview({
+                kind: 'background',
+                x: mapClamp01(x - dragging.offsetX),
+                y: mapClamp01(y - dragging.offsetY),
+            });
+        },
+        [dragging, getPointerPosition]
+    );
+
+    const handleBackgroundPointerUp = useCallback(
+        (event) => {
+            if (!dragging || dragging.kind !== 'background') return;
+            const target = event.currentTarget;
+            if (target?.releasePointerCapture) {
+                try {
+                    target.releasePointerCapture(dragging.pointerId);
+                } catch {
+                    // ignore release errors
+                }
+            }
+            const coords =
+                dragPreview && dragPreview.kind === 'background'
+                    ? { x: dragPreview.x, y: dragPreview.y }
+                    : { x: mapState.background?.x ?? 0.5, y: mapState.background?.y ?? 0.5 };
+            setDragging(null);
+            setDragPreview(null);
+            setMapState((prev) => ({
+                ...prev,
+                background: { ...prev.background, ...coords },
+            }));
+            queueBackgroundUpdate(coords);
+        },
+        [dragPreview, dragging, mapState.background?.x, mapState.background?.y, queueBackgroundUpdate]
     );
 
     const sendStroke = useCallback(
@@ -2958,24 +3221,24 @@ function MapTab({ game, me }) {
                 }
             }
             const { x, y } = getPointerPosition(event);
-            setDragging({ id: token.id, pointerId: event.pointerId });
-            setDragPreview({ id: token.id, x, y });
+            setDragging({ kind: 'token', id: token.id, pointerId: event.pointerId });
+            setDragPreview({ kind: 'token', id: token.id, x, y });
         },
         [canMoveToken, getPointerPosition]
     );
 
     const handleTokenPointerMove = useCallback(
         (token, event) => {
-            if (!dragging || dragging.id !== token.id) return;
+            if (!dragging || dragging.kind !== 'token' || dragging.id !== token.id) return;
             const { x, y } = getPointerPosition(event);
-            setDragPreview({ id: token.id, x, y });
+            setDragPreview({ kind: 'token', id: token.id, x, y });
         },
         [dragging, getPointerPosition]
     );
 
     const handleTokenPointerUp = useCallback(
         (token, event) => {
-            if (!dragging || dragging.id !== token.id) return;
+            if (!dragging || dragging.kind !== 'token' || dragging.id !== token.id) return;
             const target = event.currentTarget;
             if (target?.releasePointerCapture) {
                 try {
@@ -2985,7 +3248,7 @@ function MapTab({ game, me }) {
                 }
             }
             const coords =
-                dragPreview && dragPreview.id === token.id
+                dragPreview && dragPreview.kind === 'token' && dragPreview.id === token.id
                     ? { x: dragPreview.x, y: dragPreview.y }
                     : { x: token.x, y: token.y };
             setDragging(null);
@@ -3123,6 +3386,221 @@ function MapTab({ game, me }) {
         }
     }, [enemyForm, game.id]);
 
+    const handleAddShape = useCallback(
+        async (type) => {
+            if (!isDM) return;
+            try {
+                const response = await Games.addMapShape(game.id, { type });
+                const normalized = normalizeClientMapShape(response);
+                if (normalized) {
+                    setMapState((prev) => ({
+                        ...prev,
+                        shapes: prev.shapes.concat(normalized),
+                        updatedAt: response?.updatedAt || prev.updatedAt,
+                    }));
+                }
+            } catch (err) {
+                alert(err.message);
+            }
+        },
+        [game.id, isDM]
+    );
+
+    const handleUpdateShape = useCallback(
+        async (shapeId, patch) => {
+            if (!isDM) return;
+            try {
+                const response = await Games.updateMapShape(game.id, shapeId, patch);
+                const normalized = normalizeClientMapShape(response);
+                if (normalized) {
+                    setMapState((prev) => ({
+                        ...prev,
+                        shapes: prev.shapes.map((shape) => (shape.id === shapeId ? normalized : shape)),
+                        updatedAt: response?.updatedAt || prev.updatedAt,
+                    }));
+                }
+            } catch (err) {
+                alert(err.message);
+            }
+        },
+        [game.id, isDM]
+    );
+
+    const handleRemoveShape = useCallback(
+        async (shapeId) => {
+            if (!isDM) return;
+            if (!shapeId) return;
+            if (!window.confirm('Remove this shape from the map?')) return;
+            try {
+                await Games.deleteMapShape(game.id, shapeId);
+                setMapState((prev) => ({
+                    ...prev,
+                    shapes: prev.shapes.filter((shape) => shape.id !== shapeId),
+                    updatedAt: new Date().toISOString(),
+                }));
+            } catch (err) {
+                alert(err.message);
+            }
+        },
+        [game.id, isDM]
+    );
+
+    const handleShapePointerDown = useCallback(
+        (shape, event) => {
+            if (!shape || !isDM || isBackgroundTool || tool === 'draw') return;
+            event.preventDefault();
+            event.stopPropagation();
+            const { x, y } = getPointerPosition(event);
+            const offsetX = x - shape.x;
+            const offsetY = y - shape.y;
+            const target = event.currentTarget;
+            if (target?.setPointerCapture) {
+                try {
+                    target.setPointerCapture(event.pointerId);
+                } catch {
+                    // ignore capture errors
+                }
+            }
+            setDragging({ kind: 'shape', id: shape.id, pointerId: event.pointerId, offsetX, offsetY });
+            setDragPreview({ kind: 'shape', id: shape.id, x: mapClamp01(x - offsetX), y: mapClamp01(y - offsetY) });
+        },
+        [getPointerPosition, isBackgroundTool, isDM, tool]
+    );
+
+    const handleShapePointerMove = useCallback(
+        (shape, event) => {
+            if (!shape || !dragging || dragging.kind !== 'shape' || dragging.id !== shape.id) return;
+            const { x, y } = getPointerPosition(event);
+            setDragPreview({
+                kind: 'shape',
+                id: shape.id,
+                x: mapClamp01(x - dragging.offsetX),
+                y: mapClamp01(y - dragging.offsetY),
+            });
+        },
+        [dragging, getPointerPosition]
+    );
+
+    const handleShapePointerUp = useCallback(
+        (shape, event) => {
+            if (!shape || !dragging || dragging.kind !== 'shape' || dragging.id !== shape.id) return;
+            const target = event.currentTarget;
+            if (target?.releasePointerCapture) {
+                try {
+                    target.releasePointerCapture(dragging.pointerId);
+                } catch {
+                    // ignore release errors
+                }
+            }
+            const coords =
+                dragPreview && dragPreview.kind === 'shape' && dragPreview.id === shape.id
+                    ? { x: dragPreview.x, y: dragPreview.y }
+                    : { x: shape.x, y: shape.y };
+            setDragging(null);
+            setDragPreview(null);
+            setMapState((prev) => ({
+                ...prev,
+                shapes: prev.shapes.map((entry) => (entry.id === shape.id ? { ...entry, ...coords } : entry)),
+            }));
+            handleUpdateShape(shape.id, coords);
+        },
+        [dragPreview, dragging, handleUpdateShape]
+    );
+
+    const storyConfigured = !!game.story?.webhookConfigured;
+
+    const handleShareMapToStory = useCallback(
+        async () => {
+            if (!isDM) return;
+            if (!storyConfigured) {
+                alert('Connect a story log webhook in Campaign Settings to share battle maps.');
+                return;
+            }
+            const lines = ['Battle map update from the DM board.'];
+            if (mapState.background?.url) {
+                lines.push(mapState.background.url);
+            }
+            const tokenSummary = mapState.tokens.map((token) => token.label).filter(Boolean).join(', ');
+            if (tokenSummary) {
+                lines.push(`Tokens in play: ${tokenSummary}`);
+            }
+            try {
+                await StoryLogs.post(game.id, { persona: 'dm', content: lines.join('\n') });
+            } catch (err) {
+                alert(err.message);
+            }
+        },
+        [game.id, isDM, mapState.background?.url, mapState.tokens, storyConfigured]
+    );
+
+    const handleSaveMap = useCallback(async () => {
+        if (!isDM) return;
+        const defaultName = `Battle Map ${mapLibrary.length + 1}`;
+        const name = typeof window !== 'undefined' ? window.prompt('Name this battle map', defaultName) : defaultName;
+        if (name === null) return;
+        try {
+            const response = await Games.saveMapLibrary(game.id, name);
+            if (Array.isArray(response?.maps)) {
+                setMapLibrary(normalizeMapLibrary(response.maps));
+            } else if (response?.entry) {
+                setMapLibrary((prev) => normalizeMapLibrary(prev.concat(response.entry)));
+            } else {
+                await refreshMapLibrary();
+            }
+        } catch (err) {
+            alert(err.message);
+        }
+    }, [game.id, isDM, mapLibrary.length, refreshMapLibrary]);
+
+    const handleLoadSavedMap = useCallback(
+        async (entry) => {
+            if (!isDM || !entry?.id) return;
+            if (typeof window !== 'undefined') {
+                const confirmed = window.confirm(`Load "${entry.name}" and replace the current battle map?`);
+                if (!confirmed) return;
+            }
+            try {
+                const response = await Games.loadMapLibrary(game.id, entry.id);
+                if (response?.map) {
+                    setMapState(normalizeClientMapState(response.map));
+                }
+                if (Array.isArray(response?.maps)) {
+                    setMapLibrary(normalizeMapLibrary(response.maps));
+                } else if (response?.entry) {
+                    setMapLibrary((prev) =>
+                        normalizeMapLibrary(prev.map((item) => (item.id === response.entry.id ? response.entry : item)))
+                    );
+                } else {
+                    await refreshMapLibrary();
+                }
+            } catch (err) {
+                alert(err.message);
+            }
+        },
+        [game.id, isDM, refreshMapLibrary]
+    );
+
+    const handleDeleteSavedMap = useCallback(
+        async (entry) => {
+            if (!isDM || !entry?.id) return;
+            if (typeof window !== 'undefined') {
+                const confirmed = window.confirm(`Delete "${entry.name}" from your saved battle maps?`);
+                if (!confirmed) return;
+            }
+            try {
+                const response = await Games.deleteMapLibrary(game.id, entry.id);
+                if (Array.isArray(response?.maps)) {
+                    setMapLibrary(normalizeMapLibrary(response.maps));
+                } else {
+                    setMapLibrary((prev) => prev.filter((item) => item.id !== entry.id));
+                }
+            } catch (err) {
+                alert(err.message);
+            }
+        },
+        [game.id, isDM]
+    );
+
     const handleTogglePause = useCallback(async () => {
         try {
             const updated = await Games.updateMapSettings(game.id, { paused: !mapState.paused });
@@ -3154,6 +3632,15 @@ function MapTab({ game, me }) {
                             >
                                 Draw
                             </button>
+                            {isDM && (
+                                <button
+                                    type="button"
+                                    className={`btn btn-small${tool === 'background' ? ' is-active' : ' secondary'}`}
+                                    onClick={() => setTool('background')}
+                                >
+                                    Background
+                                </button>
+                            )}
                         </div>
                     </div>
                     <div className="map-toolbar__status">
@@ -3163,6 +3650,21 @@ function MapTab({ game, me }) {
                         {isDM && (
                             <button type="button" className="btn btn-small" onClick={handleTogglePause}>
                                 {mapState.paused ? 'Resume sharing' : 'Pause updates'}
+                            </button>
+                        )}
+                        {isDM && (
+                            <button
+                                type="button"
+                                className="btn btn-small secondary"
+                                onClick={handleShareMapToStory}
+                                disabled={!storyConfigured}
+                                title={
+                                    storyConfigured
+                                        ? 'Post the current map background and token summary to the story log.'
+                                        : 'Connect a story log webhook in Campaign Settings to share battle maps.'
+                                }
+                            >
+                                Share to story log
                             </button>
                         )}
                     </div>
@@ -3212,22 +3714,81 @@ function MapTab({ game, me }) {
             </div>
             <div className="map-layout">
                 <div className="map-board card" ref={boardRef}>
+                    <div
+                        className="map-board__background"
+                        style={{ pointerEvents: isDM && isBackgroundTool ? 'auto' : 'none' }}
+                    >
+                        {backgroundDisplay.url && (
+                            <img
+                                src={backgroundDisplay.url}
+                                alt=""
+                                className="map-board__background-image"
+                                style={{
+                                    left: `${backgroundDisplay.x * 100}%`,
+                                    top: `${backgroundDisplay.y * 100}%`,
+                                    width: `${backgroundDisplay.scale * 100}%`,
+                                    opacity: backgroundDisplay.opacity,
+                                    transform: `translate(-50%, -50%) rotate(${backgroundDisplay.rotation}deg)`,
+                                }}
+                                draggable={false}
+                                onPointerDown={handleBackgroundPointerDown}
+                                onPointerMove={handleBackgroundPointerMove}
+                                onPointerUp={handleBackgroundPointerUp}
+                                onPointerCancel={handleBackgroundPointerUp}
+                            />
+                        )}
+                    </div>
                     <canvas
                         ref={canvasRef}
                         className="map-board__canvas"
+                        style={{ pointerEvents: canvasPointerEvents }}
                         onPointerDown={handleCanvasPointerDown}
                         onPointerMove={handleCanvasPointerMove}
                         onPointerUp={handleCanvasPointerFinish}
                         onPointerCancel={handleCanvasPointerFinish}
                         onPointerLeave={handleCanvasPointerFinish}
                     />
+                    <div className="map-board__shapes" style={{ pointerEvents: shapeLayerPointerEvents }}>
+                        {mapState.shapes.map((shape) => {
+                            const display =
+                                dragPreview && dragPreview.kind === 'shape' && dragPreview.id === shape.id
+                                    ? { ...shape, x: dragPreview.x, y: dragPreview.y }
+                                    : shape;
+                            const widthPercent = Math.max(display.width * 100, 1);
+                            const heightPercent = Math.max(display.height * 100, 1);
+                            const style = {
+                                left: `${display.x * 100}%`,
+                                top: `${display.y * 100}%`,
+                                width: `${widthPercent}%`,
+                                height: `${heightPercent}%`,
+                                transform: `translate(-50%, -50%) rotate(${display.rotation}deg)`,
+                                background: display.type === 'line' ? display.stroke : display.fill,
+                                opacity: display.opacity,
+                                borderColor: display.stroke,
+                                borderWidth: display.type === 'line' ? 0 : `${display.strokeWidth}px`,
+                                borderStyle: 'solid',
+                            };
+                            return (
+                                <div
+                                    key={shape.id}
+                                    className={`map-shape map-shape--${display.type}`}
+                                    style={style}
+                                    onPointerDown={(event) => handleShapePointerDown(shape, event)}
+                                    onPointerMove={(event) => handleShapePointerMove(shape, event)}
+                                    onPointerUp={(event) => handleShapePointerUp(shape, event)}
+                                    onPointerCancel={(event) => handleShapePointerUp(shape, event)}
+                                />
+                            );
+                        })}
+                    </div>
                     <div className="map-board__tokens" style={{ pointerEvents: tokenLayerPointerEvents }}>
                         {mapState.tokens.map((token) => {
                             const player = token.kind === 'player' ? playerMap.get(token.refId) : null;
                             const demon = token.kind === 'demon' ? demonMap.get(token.refId) : null;
-                            const display = dragPreview && dragPreview.id === token.id
-                                ? { ...token, x: dragPreview.x, y: dragPreview.y }
-                                : token;
+                            const display =
+                                dragPreview && dragPreview.kind === 'token' && dragPreview.id === token.id
+                                    ? { ...token, x: dragPreview.x, y: dragPreview.y }
+                                    : token;
                             const showTooltip = token.showTooltip && token.tooltip;
                             const canDrag = canMoveToken(token);
                             const label = token.label || (player ? describePlayerName(player) : demon ? demon.name : 'Marker');
@@ -3510,6 +4071,374 @@ function MapTab({ game, me }) {
                             </div>
                         )}
                     </div>
+                    {isDM && (
+                        <div className="map-panel card">
+                            <h3>Background image</h3>
+                            <label className="text-small" htmlFor="map-background-url">Image URL</label>
+                            <input
+                                id="map-background-url"
+                                type="text"
+                                value={backgroundDraft.url}
+                                onChange={(event) =>
+                                    setBackgroundDraft((prev) => ({ ...prev, url: event.target.value || '' }))
+                                }
+                                placeholder="https://example.com/map.png"
+                            />
+                            <div className="row" style={{ gap: 8, flexWrap: 'wrap' }}>
+                                <button
+                                    type="button"
+                                    className="btn btn-small"
+                                    onClick={() => {
+                                        const trimmed = (backgroundDraft.url || '').trim();
+                                        if (!trimmed) return;
+                                        handleUpdateBackground({ url: trimmed });
+                                    }}
+                                    disabled={!backgroundDraft.url || !backgroundDraft.url.trim()}
+                                >
+                                    Apply URL
+                                </button>
+                                <button
+                                    type="button"
+                                    className="btn btn-small ghost"
+                                    onClick={handleClearBackground}
+                                    disabled={!mapState.background?.url}
+                                >
+                                    Clear
+                                </button>
+                            </div>
+                            <div className="map-background-controls">
+                                <label className="map-background-slider">
+                                    <span className="text-small">Horizontal</span>
+                                    <input
+                                        type="range"
+                                        min="0"
+                                        max="100"
+                                        value={Math.round((backgroundDraft.x ?? 0.5) * 100)}
+                                        onChange={(event) => {
+                                            const value = clamp(Number(event.target.value) / 100, 0, 1, backgroundDraft.x ?? 0.5);
+                                            queueBackgroundUpdate({ x: value });
+                                        }}
+                                    />
+                                </label>
+                                <label className="map-background-slider">
+                                    <span className="text-small">Vertical</span>
+                                    <input
+                                        type="range"
+                                        min="0"
+                                        max="100"
+                                        value={Math.round((backgroundDraft.y ?? 0.5) * 100)}
+                                        onChange={(event) => {
+                                            const value = clamp(Number(event.target.value) / 100, 0, 1, backgroundDraft.y ?? 0.5);
+                                            queueBackgroundUpdate({ y: value });
+                                        }}
+                                    />
+                                </label>
+                                <label className="map-background-slider">
+                                    <span className="text-small">Scale ({backgroundDraft.scale.toFixed(2)}x)</span>
+                                    <input
+                                        type="range"
+                                        min="20"
+                                        max="400"
+                                        value={Math.round((backgroundDraft.scale ?? 1) * 100)}
+                                        onChange={(event) => {
+                                            const value = clamp(Number(event.target.value) / 100, 0.2, 4, backgroundDraft.scale ?? 1);
+                                            queueBackgroundUpdate({ scale: value });
+                                        }}
+                                    />
+                                </label>
+                                <label className="map-background-slider">
+                                    <span className="text-small">Rotation ({Math.round(backgroundDraft.rotation)}°)</span>
+                                    <input
+                                        type="range"
+                                        min="0"
+                                        max="360"
+                                        value={Math.round(backgroundDraft.rotation)}
+                                        onChange={(event) => {
+                                            const value = clamp(Number(event.target.value), 0, 360, backgroundDraft.rotation);
+                                            queueBackgroundUpdate({ rotation: value });
+                                        }}
+                                    />
+                                </label>
+                                <label className="map-background-slider">
+                                    <span className="text-small">Opacity ({Math.round(backgroundDraft.opacity * 100)}%)</span>
+                                    <input
+                                        type="range"
+                                        min="10"
+                                        max="100"
+                                        value={Math.round((backgroundDraft.opacity ?? 1) * 100)}
+                                        onChange={(event) => {
+                                            const value = clamp(Number(event.target.value) / 100, 0.1, 1, backgroundDraft.opacity ?? 1);
+                                            queueBackgroundUpdate({ opacity: value });
+                                        }}
+                                    />
+                                </label>
+                            </div>
+                        </div>
+                    )}
+                    <div className="map-panel card">
+                        <h3>Battle shapes</h3>
+                        {isDM && (
+                            <div className="map-panel__add">
+                                <span className="text-small">Add shape</span>
+                                <div className="row" style={{ gap: 8, flexWrap: 'wrap' }}>
+                                    {MAP_SHAPE_TYPES.map((type) => (
+                                        <button
+                                            key={type}
+                                            type="button"
+                                            className="btn btn-small secondary"
+                                            onClick={() => handleAddShape(type)}
+                                        >
+                                            {type === 'rectangle' ? 'Rectangle' : type === 'circle' ? 'Circle' : 'Line'}
+                                        </button>
+                                    ))}
+                                </div>
+                            </div>
+                        )}
+                        {mapState.shapes.length === 0 ? (
+                            <p className="map-empty text-muted">No shapes placed.</p>
+                        ) : (
+                            <div className="list">
+                                {mapState.shapes.map((shape, index) => (
+                                    <div key={shape.id} className="map-shape-row">
+                                        <div className="map-shape-row__header">
+                                            <strong>
+                                                {`${shape.type.charAt(0).toUpperCase()}${shape.type.slice(1)} ${index + 1}`}
+                                            </strong>
+                                            {isDM && (
+                                                <button
+                                                    type="button"
+                                                    className="btn ghost btn-small"
+                                                    onClick={() => handleRemoveShape(shape.id)}
+                                                >
+                                                    Remove
+                                                </button>
+                                            )}
+                                        </div>
+                                        {isDM && (
+                                            <div className="map-shape-row__controls">
+                                                {shape.type !== 'line' && (
+                                                    <label className="color-input">
+                                                        <span className="text-small">Fill</span>
+                                                        <input
+                                                            type="color"
+                                                            value={shape.fill}
+                                                            onChange={(event) => {
+                                                                const value = event.target.value || shape.fill;
+                                                                setMapState((prev) => ({
+                                                                    ...prev,
+                                                                    shapes: prev.shapes.map((entry) =>
+                                                                        entry.id === shape.id
+                                                                            ? { ...entry, fill: value }
+                                                                            : entry
+                                                                    ),
+                                                                }));
+                                                                handleUpdateShape(shape.id, { fill: value });
+                                                            }}
+                                                        />
+                                                        <span className="text-muted text-small">{shape.fill.toUpperCase()}</span>
+                                                    </label>
+                                                )}
+                                                <label className="color-input">
+                                                    <span className="text-small">Stroke</span>
+                                                    <input
+                                                        type="color"
+                                                        value={shape.stroke}
+                                                        onChange={(event) => {
+                                                            const value = event.target.value || shape.stroke;
+                                                            setMapState((prev) => ({
+                                                                ...prev,
+                                                                shapes: prev.shapes.map((entry) =>
+                                                                    entry.id === shape.id
+                                                                        ? { ...entry, stroke: value }
+                                                                        : entry
+                                                                ),
+                                                            }));
+                                                            handleUpdateShape(shape.id, { stroke: value });
+                                                        }}
+                                                    />
+                                                    <span className="text-muted text-small">{shape.stroke.toUpperCase()}</span>
+                                                </label>
+                                                <label className="map-shape-slider">
+                                                    <span className="text-small">Width ({Math.round(shape.width * 100)}%)</span>
+                                                    <input
+                                                        type="range"
+                                                        min="5"
+                                                        max="100"
+                                                        value={Math.round(shape.width * 100)}
+                                                        onChange={(event) => {
+                                                            const value = clamp(Number(event.target.value) / 100, 0.05, 1, shape.width);
+                                                            setMapState((prev) => ({
+                                                                ...prev,
+                                                                shapes: prev.shapes.map((entry) =>
+                                                                    entry.id === shape.id
+                                                                        ? {
+                                                                              ...entry,
+                                                                              width: value,
+                                                                              ...(entry.type === 'circle' ? { height: value } : {}),
+                                                                          }
+                                                                        : entry
+                                                                ),
+                                                            }));
+                                                            handleUpdateShape(shape.id, {
+                                                                width: value,
+                                                                ...(shape.type === 'circle' ? { height: value } : {}),
+                                                            });
+                                                        }}
+                                                    />
+                                                </label>
+                                                {shape.type !== 'circle' && (
+                                                    <label className="map-shape-slider">
+                                                        <span className="text-small">Height ({Math.round(shape.height * 100)}%)</span>
+                                                        <input
+                                                            type="range"
+                                                            min="5"
+                                                            max="100"
+                                                            value={Math.round(shape.height * 100)}
+                                                            onChange={(event) => {
+                                                                const value = clamp(
+                                                                    Number(event.target.value) / 100,
+                                                                    0.05,
+                                                                    1,
+                                                                    shape.height
+                                                                );
+                                                                setMapState((prev) => ({
+                                                                    ...prev,
+                                                                    shapes: prev.shapes.map((entry) =>
+                                                                        entry.id === shape.id
+                                                                            ? { ...entry, height: value }
+                                                                            : entry
+                                                                    ),
+                                                                }));
+                                                                handleUpdateShape(shape.id, { height: value });
+                                                            }}
+                                                        />
+                                                    </label>
+                                                )}
+                                                <label className="map-shape-slider">
+                                                    <span className="text-small">Stroke ({Math.round(shape.strokeWidth)}px)</span>
+                                                    <input
+                                                        type="range"
+                                                        min="0"
+                                                        max="20"
+                                                        value={Math.round(shape.strokeWidth)}
+                                                        onChange={(event) => {
+                                                            const value = clamp(Number(event.target.value), 0, 20, shape.strokeWidth);
+                                                            setMapState((prev) => ({
+                                                                ...prev,
+                                                                shapes: prev.shapes.map((entry) =>
+                                                                    entry.id === shape.id
+                                                                        ? { ...entry, strokeWidth: value }
+                                                                        : entry
+                                                                ),
+                                                            }));
+                                                            handleUpdateShape(shape.id, { strokeWidth: value });
+                                                        }}
+                                                    />
+                                                </label>
+                                                <label className="map-shape-slider">
+                                                    <span className="text-small">Rotation ({Math.round(shape.rotation)}°)</span>
+                                                    <input
+                                                        type="range"
+                                                        min="0"
+                                                        max="360"
+                                                        value={Math.round(shape.rotation)}
+                                                        onChange={(event) => {
+                                                            const value = clamp(Number(event.target.value), 0, 360, shape.rotation);
+                                                            setMapState((prev) => ({
+                                                                ...prev,
+                                                                shapes: prev.shapes.map((entry) =>
+                                                                    entry.id === shape.id
+                                                                        ? { ...entry, rotation: value }
+                                                                        : entry
+                                                                ),
+                                                            }));
+                                                            handleUpdateShape(shape.id, { rotation: value });
+                                                        }}
+                                                    />
+                                                </label>
+                                                <label className="map-shape-slider">
+                                                    <span className="text-small">Opacity ({Math.round(shape.opacity * 100)}%)</span>
+                                                    <input
+                                                        type="range"
+                                                        min="10"
+                                                        max="100"
+                                                        value={Math.round(shape.opacity * 100)}
+                                                        onChange={(event) => {
+                                                            const value = clamp(Number(event.target.value) / 100, 0.1, 1, shape.opacity);
+                                                            setMapState((prev) => ({
+                                                                ...prev,
+                                                                shapes: prev.shapes.map((entry) =>
+                                                                    entry.id === shape.id
+                                                                        ? { ...entry, opacity: value }
+                                                                        : entry
+                                                                ),
+                                                            }));
+                                                            handleUpdateShape(shape.id, { opacity: value });
+                                                        }}
+                                                    />
+                                                </label>
+                                            </div>
+                                        )}
+                                    </div>
+                                ))}
+                            </div>
+                        )}
+                    </div>
+                    {isDM && (
+                        <div className="map-panel card">
+                            <h3>Saved battle maps</h3>
+                            <div className="row" style={{ gap: 8, flexWrap: 'wrap' }}>
+                                <button type="button" className="btn btn-small" onClick={handleSaveMap}>
+                                    Save current map
+                                </button>
+                                <button type="button" className="btn btn-small secondary" onClick={refreshMapLibrary}>
+                                    Refresh
+                                </button>
+                            </div>
+                            {mapLibrary.length === 0 ? (
+                                <p className="map-empty text-muted">No saved maps yet.</p>
+                            ) : (
+                                <div className="list">
+                                    {mapLibrary.map((entry) => {
+                                        const updatedLabel = entry.updatedAt || entry.createdAt;
+                                        return (
+                                            <div key={entry.id} className="map-library-row">
+                                                <div className="map-library-row__info">
+                                                    <strong>{entry.name}</strong>
+                                                    {updatedLabel && (
+                                                        <div className="text-muted text-small">
+                                                            Updated {new Date(updatedLabel).toLocaleString()}
+                                                        </div>
+                                                    )}
+                                                    {entry.previewUrl && (
+                                                        <div className="map-library-row__preview text-small text-muted">
+                                                            {entry.previewUrl}
+                                                        </div>
+                                                    )}
+                                                </div>
+                                                <div className="row" style={{ gap: 8, flexWrap: 'wrap' }}>
+                                                    <button
+                                                        type="button"
+                                                        className="btn btn-small"
+                                                        onClick={() => handleLoadSavedMap(entry)}
+                                                    >
+                                                        Load
+                                                    </button>
+                                                    <button
+                                                        type="button"
+                                                        className="btn btn-small ghost"
+                                                        onClick={() => handleDeleteSavedMap(entry)}
+                                                    >
+                                                        Delete
+                                                    </button>
+                                                </div>
+                                            </div>
+                                        );
+                                    })}
+                                </div>
+                            )}
+                        </div>
+                    )}
                 </aside>
             </div>
         </div>

--- a/web/src/api.js
+++ b/web/src/api.js
@@ -465,6 +465,19 @@ export const Games = {
         api(`/api/games/${encodeURIComponent(id)}/map/strokes/${encodeURIComponent(strokeId)}`, { method: 'DELETE' }),
     clearMapStrokes: (id) =>
         api(`/api/games/${encodeURIComponent(id)}/map/strokes/clear`, { method: 'POST' }),
+    addMapShape: (id, shape) =>
+        api(`/api/games/${encodeURIComponent(id)}/map/shapes`, { method: 'POST', body: { shape } }),
+    updateMapShape: (id, shapeId, payload) =>
+        api(`/api/games/${encodeURIComponent(id)}/map/shapes/${encodeURIComponent(shapeId)}`, {
+            method: 'PUT',
+            body: payload,
+        }),
+    deleteMapShape: (id, shapeId) =>
+        api(`/api/games/${encodeURIComponent(id)}/map/shapes/${encodeURIComponent(shapeId)}`, { method: 'DELETE' }),
+    updateMapBackground: (id, payload) =>
+        api(`/api/games/${encodeURIComponent(id)}/map/background`, { method: 'PUT', body: payload }),
+    clearMapBackground: (id) =>
+        api(`/api/games/${encodeURIComponent(id)}/map/background`, { method: 'DELETE' }),
     addMapToken: (id, token) =>
         api(`/api/games/${encodeURIComponent(id)}/map/tokens`, { method: 'POST', body: token }),
     updateMapToken: (id, tokenId, payload) =>
@@ -474,6 +487,16 @@ export const Games = {
         }),
     deleteMapToken: (id, tokenId) =>
         api(`/api/games/${encodeURIComponent(id)}/map/tokens/${encodeURIComponent(tokenId)}`, { method: 'DELETE' }),
+    listMapLibrary: async (id) => {
+        const result = await api(`/api/games/${encodeURIComponent(id)}/map/library`);
+        return Array.isArray(result?.maps) ? result.maps : [];
+    },
+    saveMapLibrary: (id, name) =>
+        api(`/api/games/${encodeURIComponent(id)}/map/library`, { method: 'POST', body: { name } }),
+    deleteMapLibrary: (id, entryId) =>
+        api(`/api/games/${encodeURIComponent(id)}/map/library/${encodeURIComponent(entryId)}`, { method: 'DELETE' }),
+    loadMapLibrary: (id, entryId) =>
+        api(`/api/games/${encodeURIComponent(id)}/map/library/${encodeURIComponent(entryId)}/load`, { method: 'POST' }),
 
     // Optional: full pagination helper example if the backend supports it
     listAll: (query) => apiClient.getAllPages('/api/games', { query }),

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -511,19 +511,67 @@ p  { margin: 0 0 .75rem; color: var(--text); }
     overflow: hidden;
     min-height: 400px;
     border-radius: var(--radius-lg);
+    background: linear-gradient(135deg, rgba(59, 130, 246, 0.06), rgba(59, 130, 246, 0.12));
+}
+
+.map-board__background,
+.map-board__shapes,
+.map-board__tokens {
+    position: absolute;
+    inset: 0;
+}
+
+.map-board__background {
+    z-index: 0;
+    overflow: hidden;
+}
+
+.map-board__background-image {
+    position: absolute;
+    top: 0;
+    left: 0;
+    max-width: none;
+    max-height: none;
+    transform-origin: center;
+    user-select: none;
+    pointer-events: inherit;
 }
 
 .map-board__canvas {
+    position: relative;
+    z-index: 1;
     width: 100%;
     height: 100%;
     display: block;
     touch-action: none;
-    background: linear-gradient(135deg, rgba(59, 130, 246, 0.06), rgba(59, 130, 246, 0.12));
+    background: transparent;
+}
+
+.map-board__shapes {
+    z-index: 2;
+    pointer-events: none;
 }
 
 .map-board__tokens {
+    z-index: 3;
+}
+
+.map-shape {
     position: absolute;
-    inset: 0;
+    transform-origin: center;
+    transform: translate(-50%, -50%);
+    border-radius: 12px;
+    box-shadow: 0 4px 12px rgba(15, 23, 42, 0.25);
+    transition: box-shadow var(--trans-fast), transform var(--trans-fast);
+    pointer-events: auto;
+}
+
+.map-shape--line {
+    border-radius: 999px;
+}
+
+.map-shape:hover {
+    box-shadow: 0 8px 18px rgba(15, 23, 42, 0.35);
 }
 
 .map-token {
@@ -620,9 +668,67 @@ p  { margin: 0 0 .75rem; color: var(--text); }
     gap: 12px;
 }
 
+.map-background-controls,
+.map-shape-row__controls {
+    display: grid;
+    gap: 8px;
+}
+
+.map-background-slider,
+.map-shape-slider {
+    display: grid;
+    gap: 4px;
+}
+
+.map-background-slider input[type="range"],
+.map-shape-slider input[type="range"] {
+    width: 100%;
+}
+
 .map-panel__add {
     display: grid;
     gap: 8px;
+}
+
+.map-shape-row {
+    display: grid;
+    gap: 12px;
+    padding: 10px 0;
+    border-bottom: 1px solid var(--border);
+}
+
+.map-shape-row:last-child {
+    border-bottom: none;
+}
+
+.map-shape-row__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+}
+
+.map-library-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 12px;
+    padding: 10px 0;
+    border-bottom: 1px solid var(--border);
+}
+
+.map-library-row:last-child {
+    border-bottom: none;
+}
+
+.map-library-row__info {
+    display: grid;
+    gap: 4px;
+}
+
+.map-library-row__preview {
+    word-break: break-all;
+    color: var(--muted);
 }
 
 .map-token-row {


### PR DESCRIPTION
## Summary
- extend the game map model with background data, draggable shapes, and a saved map library
- add server endpoints and client API helpers for managing shapes, backgrounds, and saved battle maps
- refresh the map tab UI with background editing controls, shape tooling, saved map management, and a share-to-story-log shortcut
- style the board for layered backgrounds and shapes alongside new sidebar panels

## Testing
- `npm run lint` *(fails: missing npm dependencies and cannot install without registry access)*
- `npm run build` *(fails: vite binary unavailable because dependencies cannot be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1b4f3a94c8331aef0a43d9868de69