### PR TITLE
Fix websocket proxy for Vite dev server

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -16,7 +16,14 @@ export default defineConfig({
                 ws: true,
                 // if your backend expects the path without the /api prefix, uncomment:
                 // rewrite: (path) => path.replace(/^\/api/, '')
-            }
+            },
+            // Proxy websocket connections used for real-time features in dev mode
+            '/ws': {
+                target: 'ws://127.0.0.1:3000',
+                changeOrigin: true,
+                secure: false,
+                ws: true,
+            },
         }
     }
 })


### PR DESCRIPTION
## Summary
- add a Vite dev-server proxy rule for `/ws` so WebSocket traffic reaches the API during development

## Testing
- npm run lint *(fails: missing dependencies in the provided environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1c1e845408331a2a19da1db1a4695