### PR TITLE
Enhance new player setup wizard interactivity

### DIFF
--- a/web/src/style.css
+++ b/web/src/style.css
@@ -2479,7 +2479,12 @@ label {
 /* Wizard overlay */
 .wizard-backdrop { position: fixed; inset: 0; background: rgba(15, 17, 21, 0.78); display: grid; place-items: center; padding: 24px; z-index: 20; }
 .wizard-panel { width: min(960px, 100%); max-height: 100%; overflow: hidden; border-radius: var(--radius-lg); background: var(--surface); display: grid; grid-template-rows: auto auto 1fr auto; box-shadow: 0 30px 80px rgba(0,0,0,0.35); }
-.wizard-header { display: flex; justify-content: space-between; align-items: center; padding: 16px 24px; gap: 12px; border-bottom: 1px solid var(--border); }
+.wizard-header { display: flex; justify-content: space-between; align-items: flex-start; padding: 16px 24px; gap: 12px; border-bottom: 1px solid var(--border); flex-wrap: wrap; }
+.wizard-header__text { flex: 1 1 280px; display: grid; gap: 8px; }
+.wizard-header__actions { display: flex; align-items: center; gap: 8px; }
+.wizard-progress { position: relative; width: 100%; height: 6px; border-radius: 999px; background: color-mix(in srgb, var(--brand) 12%, transparent); overflow: hidden; }
+.wizard-progress__bar { position: absolute; inset: 0; background: var(--brand); transition: width var(--trans-fast) ease-in-out; border-radius: inherit; }
+.wizard-progress__meta { font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--muted); font-weight: 600; }
 .wizard-stepper { display: flex; flex-wrap: wrap; gap: 8px; padding: 12px 24px; border-bottom: 1px solid var(--border); }
 .wizard-step { flex: 1 1 160px; border: 1px solid var(--border); border-radius: var(--radius-sm); padding: 8px 10px; background: var(--surface-2); color: var(--muted); font-weight: 600; letter-spacing: 0.03em; cursor: pointer; transition: border-color var(--trans-fast), background var(--trans-fast), color var(--trans-fast); }
 .wizard-step.is-active { border-color: var(--brand); color: var(--text); box-shadow: var(--focus); background: var(--surface); }
@@ -2489,6 +2494,14 @@ label {
 .wizard-content { padding: 24px; overflow-y: auto; max-height: 60vh; }
 .wizard-footer { padding: 16px 24px; border-top: 1px solid var(--border); display: flex; justify-content: space-between; align-items: center; gap: 12px; flex-wrap: wrap; }
 .wizard-footer__actions { display: flex; gap: 8px; }
+
+.wizard-prompt { display: grid; gap: 12px; border: 1px dashed color-mix(in srgb, var(--brand) 35%, transparent); border-radius: var(--radius); background: color-mix(in srgb, var(--brand) 10%, transparent); padding: 16px; }
+.wizard-prompt__body { display: grid; gap: 6px; }
+.wizard-prompt__title { font-size: 0.8rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.08em; color: var(--brand); }
+.wizard-prompt__hook { margin: 0; font-weight: 600; }
+.wizard-prompt__question { margin: 0; color: var(--muted); font-style: italic; }
+.wizard-prompt__actions { display: flex; flex-wrap: wrap; gap: 8px; }
+.wizard-prompt__hint { font-size: 0.75rem; font-weight: 600; color: var(--success); }
 
 .persona-overlay {
     position: fixed;


### PR DESCRIPTION
## Summary
- introduce curated concept prompts with quick actions to inspire new players
to fill in their backgrounds
- display a step-by-step progress indicator and onboarding copy directly in the
wizard header
- add accompanying styles for the prompt card and progress bar to polish the
wizard experience

## Testing
- npm run lint *(fails: missing npm dependencies in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1c2411a5c8331ad04e41c7bad1bbd