### PR TITLE
Fix Demon tab crash by initializing editing state earlier

### DIFF
--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -12522,12 +12522,12 @@ function DemonTab({ game, me, onUpdate }) {
     const [q, setQ] = useState("");
     const [results, setResults] = useState([]);
     const [selected, setSelected] = useState(null);
+    const [editing, setEditing] = useState(null);
     const previewStats = useMemo(() => resolveAbilityState(stats), [stats]);
     const previewMods = useMemo(() => {
         const source = (selected && selected.mods) || (editing && editing.mods);
         return source && typeof source === "object" ? source : EMPTY_OBJECT;
     }, [editing, selected]);
-    const [editing, setEditing] = useState(null);
     const [busySave, setBusySave] = useState(false);
     const [busySearch, setBusySearch] = useState(false);
     const [busyDelete, setBusyDelete] = useState(null);


### PR DESCRIPTION
## Summary
- initialize the editing state before it is referenced in the Demon tab component
- ensure the tab renders without throwing due to an uninitialised `editing` reference

## Testing
- npm run lint *(fails: missing dev dependencies and npm registry access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68d1d10ad14883318553783ed5b132d9