### PR TITLE
Add collapsible sidebar navigation and revamp matrix rain

### DIFF
--- a/web/src/MatrixRain.jsx
+++ b/web/src/MatrixRain.jsx
@@ -1,18 +1,20 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { onApiActivity } from './api';
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { onApiActivity } from "./api";
 
-const COLUMN_COUNT = 28;
-const GLYPHS = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ';
-const ROWS = 32;
+const GLYPHS = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+const MIN_FONT_SIZE = 16;
 
 function randomGlyph() {
     return GLYPHS[Math.floor(Math.random() * GLYPHS.length)];
 }
 
 function useLocationSignal() {
-    const [signal, setSignal] = useState(() => (typeof window !== 'undefined' ? window.location.href : ''));
+    const [signal, setSignal] = useState(() =>
+        typeof window !== "undefined" ? window.location.href : ""
+    );
+
     useEffect(() => {
-        if (typeof window === 'undefined') return undefined;
+        if (typeof window === "undefined") return undefined;
         let lastHref = window.location.href;
         const notify = () => {
             const current = window.location.href;
@@ -22,7 +24,7 @@ function useLocationSignal() {
             }
         };
         const handlePop = () => notify();
-        window.addEventListener('popstate', handlePop);
+        window.addEventListener("popstate", handlePop);
         const { pushState, replaceState } = window.history;
         window.history.pushState = function patchedPushState(...args) {
             const result = pushState.apply(this, args);
@@ -35,103 +37,208 @@ function useLocationSignal() {
             return result;
         };
         return () => {
-            window.removeEventListener('popstate', handlePop);
+            window.removeEventListener("popstate", handlePop);
             window.history.pushState = pushState;
             window.history.replaceState = replaceState;
         };
     }, []);
+
     return signal;
 }
 
-function createColumns() {
-    return Array.from({ length: COLUMN_COUNT }, (_, i) => ({
-        id: i,
-        left: Math.random() * 100,
-        duration: 1.6 + Math.random() * 1.8,
-        delay: Math.random() * 1.5,
-        chars: Array.from({ length: ROWS }, randomGlyph),
-    }));
-}
-
-// Simple matrix-style rain shown when API requests are active
 export default function MatrixRain() {
+    const canvasRef = useRef(null);
+    const contextRef = useRef(null);
+    const animationRef = useRef(null);
+    const runningRef = useRef(false);
+    const fadeRef = useRef(0);
+    const columnsRef = useRef([]);
+    const fontSizeRef = useRef(MIN_FONT_SIZE);
+    const canvasSizeRef = useRef({ width: 0, height: 0 });
+    const activeRef = useRef(false);
+
     const [active, setActive] = useState(false);
     const [visible, setVisible] = useState(false);
-    const [columns, setColumns] = useState(() => []);
-    const fadeTimer = useRef(null);
     const locationSignal = useLocationSignal();
 
+    const setupColumns = useCallback((width, height) => {
+        const fontSize = fontSizeRef.current;
+        if (fontSize <= 0) return;
+        const columnCount = Math.max(1, Math.ceil(width / fontSize));
+        columnsRef.current = Array.from({ length: columnCount }, () => -Math.random() * height);
+    }, []);
+
+    const setupCanvas = useCallback(() => {
+        const canvas = canvasRef.current;
+        if (!canvas || typeof window === "undefined") {
+            return;
+        }
+        const width = window.innerWidth;
+        const height = window.innerHeight;
+        const ratio = window.devicePixelRatio || 1;
+        canvas.width = width * ratio;
+        canvas.height = height * ratio;
+        canvas.style.width = `${width}px`;
+        canvas.style.height = `${height}px`;
+        const ctx = canvas.getContext("2d");
+        if (!ctx) {
+            contextRef.current = null;
+            return;
+        }
+        ctx.setTransform(ratio, 0, 0, ratio, 0, 0);
+        const fontSize = Math.max(MIN_FONT_SIZE, Math.floor(width / 60));
+        fontSizeRef.current = fontSize;
+        canvasSizeRef.current = { width, height };
+        setupColumns(width, height);
+        ctx.clearRect(0, 0, width, height);
+        ctx.fillStyle = "rgba(0, 0, 0, 0.6)";
+        ctx.fillRect(0, 0, width, height);
+        ctx.font = `${fontSize}px "JetBrains Mono", "Fira Code", monospace`;
+        ctx.textBaseline = "top";
+        contextRef.current = ctx;
+    }, [setupColumns]);
+
+    const drawFrame = useCallback(() => {
+        const ctx = contextRef.current;
+        if (!ctx) {
+            runningRef.current = false;
+            animationRef.current = null;
+            return;
+        }
+        const { width, height } = canvasSizeRef.current;
+        if (!width || !height) {
+            runningRef.current = false;
+            animationRef.current = null;
+            return;
+        }
+
+        if (!columnsRef.current.length) {
+            setupColumns(width, height);
+        }
+
+        if (activeRef.current) {
+            fadeRef.current = Math.min(1, fadeRef.current + 0.08);
+        } else {
+            fadeRef.current = Math.max(0, fadeRef.current - 0.05);
+        }
+
+        const strength = fadeRef.current;
+
+        if (!activeRef.current && strength <= 0) {
+            ctx.globalAlpha = 1;
+            ctx.fillStyle = "rgba(0, 0, 0, 0.6)";
+            ctx.fillRect(0, 0, width, height);
+            runningRef.current = false;
+            animationRef.current = null;
+            setVisible(false);
+            return;
+        }
+
+        ctx.globalAlpha = 1;
+        ctx.fillStyle = "rgba(0, 0, 0, 0.22)";
+        ctx.fillRect(0, 0, width, height);
+
+        const fontSize = fontSizeRef.current;
+        ctx.font = `${fontSize}px "JetBrains Mono", "Fira Code", monospace`;
+
+        const glyphCount = GLYPHS.length;
+        const trailAlpha = 0.35 + strength * 0.45;
+        ctx.globalAlpha = trailAlpha;
+        ctx.fillStyle = "#64ffb3";
+        ctx.shadowColor = `rgba(102, 255, 178, ${0.28 + strength * 0.4})`;
+        ctx.shadowBlur = 14 + strength * 20;
+
+        for (let i = 0; i < columnsRef.current.length; i += 1) {
+            const y = columnsRef.current[i];
+            const x = i * fontSize;
+            const glyph = GLYPHS[Math.floor(Math.random() * glyphCount)];
+            ctx.fillText(glyph, x, y);
+            let nextY = y + fontSize * (0.85 + Math.random() * 0.35);
+            if (nextY > height + Math.random() * 240) {
+                nextY = -Math.random() * 200;
+            }
+            columnsRef.current[i] = nextY;
+        }
+
+        ctx.shadowBlur = 0;
+        ctx.globalAlpha = Math.min(1, 0.28 + strength * 0.5);
+        ctx.fillStyle = "#d0ffe9";
+        ctx.shadowColor = `rgba(208, 255, 233, ${0.25 + strength * 0.35})`;
+        ctx.shadowBlur = 22 * strength;
+
+        for (let i = 0; i < columnsRef.current.length; i += 1) {
+            const y = columnsRef.current[i] - fontSize * 0.6;
+            if (y < -fontSize) continue;
+            const x = i * fontSize;
+            ctx.fillText(randomGlyph(), x, y);
+        }
+
+        ctx.shadowBlur = 0;
+        ctx.globalAlpha = 1;
+        animationRef.current = requestAnimationFrame(drawFrame);
+    }, [setupColumns, setVisible]);
+
+    const startAnimation = useCallback(() => {
+        if (runningRef.current) {
+            return;
+        }
+        runningRef.current = true;
+        animationRef.current = requestAnimationFrame(drawFrame);
+    }, [drawFrame]);
+
+    const stopAnimation = useCallback(() => {
+        runningRef.current = false;
+        if (animationRef.current) {
+            cancelAnimationFrame(animationRef.current);
+            animationRef.current = null;
+        }
+    }, []);
+
     useEffect(() => {
-        const unsubscribe = onApiActivity(setActive);
+        if (typeof window === "undefined") return undefined;
+        setupCanvas();
+        const handleResize = () => setupCanvas();
+        window.addEventListener("resize", handleResize);
+        return () => {
+            window.removeEventListener("resize", handleResize);
+        };
+    }, [setupCanvas]);
+
+    useEffect(() => {
+        if (!visible) return;
+        setupCanvas();
+    }, [locationSignal, visible, setupCanvas]);
+
+    useEffect(() => {
+        const unsubscribe = onApiActivity((value) => setActive(!!value));
         return () => {
             unsubscribe();
-            if (fadeTimer.current) {
-                clearTimeout(fadeTimer.current);
-                fadeTimer.current = null;
-            }
         };
     }, []);
 
     useEffect(() => {
+        activeRef.current = active;
         if (active) {
             setVisible(true);
-            setColumns(() => createColumns());
-        } else {
-            if (fadeTimer.current) clearTimeout(fadeTimer.current);
-            fadeTimer.current = setTimeout(() => setVisible(false), 400);
+            setupCanvas();
+            startAnimation();
+        } else if (fadeRef.current > 0 || runningRef.current) {
+            startAnimation();
         }
-        return () => {
-            if (fadeTimer.current) {
-                clearTimeout(fadeTimer.current);
-                fadeTimer.current = null;
-            }
-        };
-    }, [active]);
+    }, [active, setupCanvas, startAnimation]);
 
-    useEffect(() => {
-        if (!visible) return;
-        setColumns(() => createColumns());
-    }, [locationSignal, visible]);
+    useEffect(() => () => stopAnimation(), [stopAnimation]);
 
-    useEffect(() => {
-        if (!active) return undefined;
-        const interval = setInterval(() => {
-            setColumns((cols) =>
-                cols.map((col) => ({
-                    ...col,
-                    chars: [randomGlyph(), ...col.chars.slice(0, ROWS - 1)],
-                }))
-            );
-        }, 95);
-        return () => clearInterval(interval);
-    }, [active]);
+    if (!visible) {
+        return null;
+    }
 
-    const content = useMemo(() => (
-        columns.map((col) => (
-            <div
-                key={col.id}
-                className="matrix-column"
-                style={{
-                    left: `${col.left}%`,
-                    animationDuration: `${col.duration}s`,
-                    animationDelay: `${col.delay}s`,
-                }}
-            >
-                {col.chars.map((char, idx) => (
-                    <span key={idx} className="matrix-char" style={{ opacity: Math.max(0.25, idx / ROWS) }}>
-                        {char}
-                    </span>
-                ))}
-            </div>
-        ))
-    ), [columns]);
-
-    if (!visible) return null;
+    const className = `matrix-rain${visible ? " is-visible" : ""}${active ? " is-active" : ""}`;
 
     return (
-        <div className={`matrix-rain${active ? ' active' : ''}`} aria-hidden>
-            {content}
+        <div className={className} aria-hidden>
+            <div className="matrix-rain__glow" />
+            <canvas ref={canvasRef} />
         </div>
     );
 }
-

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -1118,15 +1118,70 @@ p  { margin: 0 0 .75rem; color: var(--text); }
 }
 
 .app-shell {
+    position: relative;
     display: grid;
     grid-template-columns: minmax(260px, 320px) minmax(0, 1fr);
     gap: 28px;
     min-height: calc(100vh - clamp(16px, 3vw, 32px) * 2);
+    transition: grid-template-columns var(--trans-fast);
+}
+
+.app-shell.is-sidebar-collapsed {
+    grid-template-columns: minmax(0, 1fr);
+}
+
+.app-shell.is-sidebar-collapsed .app-sidebar {
+    opacity: 0;
+    transform: translateX(-32px);
+    pointer-events: none;
+}
+
+.app-shell.is-sidebar-collapsed .app-main {
+    grid-column: 1 / -1;
+}
+
+.app-shell.is-sidebar-open .app-sidebar {
+    opacity: 1;
+    transform: translateX(0);
 }
 
 @media (max-width: 960px) {
     .app-shell {
-        grid-template-columns: 1fr;
+        grid-template-columns: minmax(0, 1fr);
+    }
+
+    .app-shell::after {
+        content: "";
+        position: fixed;
+        inset: 0;
+        background: rgba(4, 10, 16, 0.55);
+        opacity: 0;
+        pointer-events: none;
+        transition: opacity var(--trans-fast);
+        z-index: 300;
+    }
+
+    .app-shell.is-sidebar-open::after {
+        opacity: 1;
+    }
+
+    .app-sidebar {
+        position: fixed;
+        top: clamp(16px, 3vw, 32px);
+        left: clamp(16px, 3vw, 32px);
+        bottom: clamp(16px, 3vw, 32px);
+        max-width: 320px;
+        width: calc(100% - clamp(16px, 3vw, 32px) * 2);
+        transform: translateX(-24px);
+        opacity: 0;
+        pointer-events: none;
+        z-index: 350;
+    }
+
+    .app-shell.is-sidebar-open .app-sidebar {
+        opacity: 1;
+        transform: translateX(0);
+        pointer-events: auto;
     }
 }
 
@@ -1139,6 +1194,7 @@ p  { margin: 0 0 .75rem; color: var(--text); }
     display: flex;
     flex-direction: column;
     gap: 24px;
+    transition: transform var(--trans-fast), opacity var(--trans-fast), box-shadow var(--trans-fast);
 }
 
 .app-sidebar .btn {
@@ -1221,6 +1277,31 @@ p  { margin: 0 0 .75rem; color: var(--text); }
     gap: 12px;
 }
 
+.sidebar__player-info {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 14px 16px;
+    border-radius: var(--radius);
+    background: color-mix(in oklab, var(--brand) 10%, var(--surface));
+    border: 1px solid color-mix(in oklab, var(--brand) 40%, var(--border));
+    box-shadow: var(--shadow-sm);
+}
+
+.sidebar__player-label {
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.22em;
+    color: var(--brand-600);
+    font-weight: 700;
+}
+
+.sidebar__player-value {
+    font-size: 1.15rem;
+    font-weight: 700;
+}
+
 .app-sidebar .invite-button {
     width: 100%;
     align-items: stretch;
@@ -1247,6 +1328,19 @@ p  { margin: 0 0 .75rem; color: var(--text); }
     justify-content: space-between;
     gap: 24px;
     align-items: flex-start;
+}
+
+.header-leading {
+    display: flex;
+    align-items: flex-start;
+    gap: 16px;
+}
+
+@media (max-width: 720px) {
+    .header-leading {
+        flex-direction: column;
+        align-items: stretch;
+    }
 }
 
 @media (max-width: 720px) {
@@ -1290,6 +1384,51 @@ p  { margin: 0 0 .75rem; color: var(--text); }
 
 .hotkey-hint {
     opacity: 0.75;
+}
+
+.sidebar-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 14px;
+    border-radius: var(--radius);
+    border: 1px solid var(--border);
+    background: var(--surface-2);
+    color: var(--text);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    cursor: pointer;
+    transition: background var(--trans-fast), border-color var(--trans-fast), color var(--trans-fast), transform var(--trans-fast);
+}
+
+.sidebar-toggle:hover {
+    background: color-mix(in oklab, var(--surface-2) 60%, var(--brand) 10%);
+    border-color: color-mix(in oklab, var(--border) 50%, var(--brand) 25%);
+}
+
+.sidebar-toggle:focus-visible {
+    outline: none;
+    box-shadow: var(--focus);
+}
+
+.sidebar-toggle.is-closed {
+    background: var(--brand);
+    border-color: color-mix(in oklab, var(--brand) 60%, transparent);
+    color: #fff;
+}
+
+.sidebar-toggle.is-closed:hover {
+    background: var(--brand-600);
+}
+
+.sidebar-toggle__icon {
+    font-size: 1.1rem;
+    line-height: 1;
+}
+
+.sidebar-toggle__label {
+    font-size: 0.78rem;
 }
 
 .header-pills {
@@ -2893,32 +3032,36 @@ pre  { padding: 12px; overflow: auto; }
     position: fixed;
     inset: 0;
     pointer-events: none;
-    background: rgba(0,0,0,0.45);
-    font-family: monospace;
-    color: #0f0;
-    z-index: 1000;
-    overflow: hidden;
+    z-index: 1200;
     opacity: 0;
-    transition: opacity 180ms ease;
+    transition: opacity 240ms ease;
+    mix-blend-mode: screen;
 }
-.matrix-rain.active {
+
+.matrix-rain.is-visible {
     opacity: 1;
 }
-.matrix-column {
-    position: absolute;
-    top: -120%;
-    display: flex;
-    flex-direction: column;
-    gap: 2px;
-    animation: matrix-fall linear infinite;
-    opacity: 0.85;
-}
-.matrix-char {
+
+.matrix-rain canvas {
+    width: 100%;
+    height: 100%;
     display: block;
-    font-size: 14px;
-    line-height: 1;
-    text-shadow: 0 0 6px rgba(0, 255, 0, 0.45);
+    filter: saturate(1.2);
 }
-@keyframes matrix-fall {
-    to { transform: translateY(200%); }
+
+.matrix-rain__glow {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background:
+        radial-gradient(circle at 20% 18%, rgba(102, 255, 190, 0.22), transparent 55%),
+        radial-gradient(circle at 78% 22%, rgba(72, 203, 255, 0.18), transparent 50%),
+        radial-gradient(circle at 50% 70%, rgba(40, 255, 150, 0.16), transparent 58%);
+    mix-blend-mode: screen;
+    opacity: 0.75;
+    transition: opacity var(--trans-fast);
+}
+
+.matrix-rain.is-active .matrix-rain__glow {
+    opacity: 1;
 }


### PR DESCRIPTION
## Summary
- add a collapsible sidebar with menu toggle, invite/main menu/logout buttons, and player macca summary
- update layout styling for the new sidebar interactions and player footer panel
- replace the CSS-based matrix rain overlay with a responsive canvas animation and refreshed visuals

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d41ba8847483318c26fd1c94cfee83