### PR TITLE
Ensure demon preview uses persona image route

### DIFF
--- a/web/src/style.css
+++ b/web/src/style.css
@@ -2426,6 +2426,64 @@ label {
 .combat-codex__unmatched { border-top: 1px solid var(--border); padding-top: 12px; }
 
 /* Demon codex */
+.demon-codex { display: grid; gap: 16px; }
+.demon-codex__layout { display: flex; flex-direction: column; gap: 16px; }
+.demon-codex__main { display: grid; gap: 16px; flex: 1 1 auto; }
+.demon-codex__panel { display: grid; gap: 16px; }
+.demon-codex__panel-header { display: flex; justify-content: space-between; align-items: flex-start; gap: 12px; flex-wrap: wrap; }
+.demon-codex__pool-usage { align-self: flex-start; font-weight: 600; }
+.demon-codex__tabs { display: flex; flex-wrap: wrap; gap: 8px; }
+.demon-codex__tab-btn { border: 1px solid var(--border); border-radius: var(--radius-sm); padding: 6px 14px; font-weight: 600; background: var(--surface-2); color: var(--muted); cursor: pointer; transition: border-color var(--trans-fast), background var(--trans-fast), color var(--trans-fast), box-shadow var(--trans-fast); }
+.demon-codex__tab-btn:hover { border-color: color-mix(in oklab, var(--brand) 35%, var(--border)); color: var(--text); }
+.demon-codex__tab-btn.is-active { border-color: var(--brand); color: var(--text); background: var(--surface); box-shadow: var(--focus); }
+.demon-codex__tab-btn:focus-visible { outline: none; border-color: var(--brand); box-shadow: var(--focus); }
+.demon-codex__content { display: grid; gap: 16px; }
+.demon-codex__aside { flex: 1 1 auto; display: grid; }
+.demon-codex__pool-mobile { display: none; justify-self: flex-start; margin-bottom: 12px; }
+
+.demon-lookup { display: grid; gap: 12px; }
+.demon-lookup__controls { display: flex; gap: 8px; flex-wrap: wrap; align-items: flex-end; }
+.demon-lookup__field { flex: 1 1 240px; min-width: 220px; }
+.demon-lookup__results { display: grid; gap: 8px; max-height: 280px; overflow-y: auto; padding-right: 4px; }
+.demon-lookup__result { display: flex; justify-content: space-between; align-items: center; gap: 12px; padding: 10px 12px; border: 1px solid var(--border); border-radius: var(--radius-sm); background: var(--surface-2); }
+.demon-lookup__name { font-weight: 600; }
+.demon-lookup__empty { border: 1px dashed var(--border); border-radius: var(--radius-sm); padding: 16px; text-align: center; }
+
+.demon-editor { display: grid; gap: 16px; align-content: start; }
+.demon-editor__content { display: grid; gap: 16px; }
+.demon-editor__header { display: flex; justify-content: space-between; align-items: flex-start; gap: 12px; }
+.demon-editor__title { margin: 0; }
+.demon-editor__actions { display: flex; gap: 8px; flex-wrap: wrap; }
+.demon-editor__section { display: grid; gap: 12px; }
+.demon-editor__row { display: flex; gap: 12px; flex-wrap: wrap; }
+.demon-editor__field { flex: 1 1 180px; min-width: 180px; }
+.demon-editor__field--compact { flex: 0 0 120px; }
+.demon-editor__field--wide { flex: 1 1 260px; min-width: 240px; }
+.demon-editor__stats-grid { display: grid; gap: 8px; grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); }
+.demon-editor__stat-field { gap: 4px; }
+.demon-editor__resist-grid { display: grid; gap: 8px; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); }
+.demon-editor__resist-field textarea { min-height: 72px; }
+.demon-editor__preview { display: grid; gap: 12px; }
+.demon-editor__preview-body { display: grid; gap: 12px; }
+.demon-editor__preview-image { width: 100%; border-radius: var(--radius); border: 1px solid var(--border); background: #0b0c10; object-fit: cover; max-height: 260px; }
+.demon-editor__preview-meta { display: grid; gap: 8px; }
+.demon-editor__preview-stats { display: flex; flex-wrap: wrap; gap: 6px; }
+.demon-editor__preview-resists { display: grid; gap: 4px; }
+
+.demon-fusion { display: grid; gap: 8px; padding: 16px; border: 1px dashed var(--border); border-radius: var(--radius); background: color-mix(in oklab, var(--brand) 8%, transparent); }
+
+@media (min-width: 960px) {
+    .demon-codex__layout { flex-direction: row; align-items: flex-start; }
+    .demon-codex__main { flex: 2 1 0; }
+    .demon-codex__aside { flex: 1 1 360px; position: sticky; top: 0; align-self: flex-start; }
+}
+
+@media (max-width: 959px) {
+    .demon-codex__pool-usage { display: none; }
+    .demon-codex__pool-mobile { display: inline-flex; }
+    .demon-codex__panel-header { flex-direction: column; align-items: flex-start; }
+}
+
 .demon-codex__filters { display: flex; flex-wrap: wrap; gap: 12px; margin-top: 16px; align-items: flex-end; }
 .demon-codex__filter { flex: 1 1 180px; min-width: 180px; }
 .demon-codex__clear { align-self: center; }


### PR DESCRIPTION
## Summary
- add persona slug-aware image source handling so demon previews can load artwork through `/api/personas/:slug/image`
- provide the persona slug to demon cards and the editor preview so selections display art even when the raw image path is local

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4234272f88331a3f183a1f44b70ad