### PR TITLE
Fix sidebar close control overlap and invite sizing

### DIFF
--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -2317,6 +2317,10 @@ function GameView({
         setSidebarOpen((prev) => !prev);
     }, []);
 
+    const closeSidebar = useCallback(() => {
+        setSidebarOpen(false);
+    }, []);
+
     useEffect(() => {
         if (navItems.length === 0) return;
         if (!navItems.some((item) => item.key === tab)) {
@@ -2538,15 +2542,27 @@ function GameView({
                         aria-hidden={!sidebarOpen}
                     >
                         <div className="sidebar__header">
-                            <span className="sidebar__mode">
-                                {isDM ? "Dungeon Master Mode" : "Player Mode"}
-                            </span>
-                            <h2 className="sidebar__title">{game.name}</h2>
-                            <p className="sidebar__summary">
-                                {isDM
-                                    ? "Share quick links, manage characters, and keep your table organized."
-                                    : "Track your hero, review the party, and stay aligned with your DM."}
-                            </p>
+                            <div className="sidebar__header-main">
+                                <span className="sidebar__mode">
+                                    {isDM ? "Dungeon Master Mode" : "Player Mode"}
+                                </span>
+                                <h2 className="sidebar__title">{game.name}</h2>
+                                <p className="sidebar__summary">
+                                    {isDM
+                                        ? "Share quick links, manage characters, and keep your table organized."
+                                        : "Track your hero, review the party, and stay aligned with your DM."}
+                                </p>
+                            </div>
+                            <button
+                                type="button"
+                                className="sidebar__close"
+                                onClick={closeSidebar}
+                                aria-label="Close menu"
+                                title="Close menu"
+                                hidden={!sidebarOpen}
+                            >
+                                <span aria-hidden>×</span>
+                            </button>
                         </div>
                         <nav className="sidebar__nav">
                             {navItems.map((item) => (

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -1568,8 +1568,50 @@ p  { margin: 0 0 .75rem; color: var(--text); }
 }
 
 .sidebar__header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 16px;
+}
+
+.sidebar__header-main {
     display: grid;
     gap: 6px;
+    flex: 1 1 auto;
+    min-width: 0;
+}
+
+.sidebar__close {
+    display: none;
+    align-items: center;
+    justify-content: center;
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    border: 1px solid var(--border);
+    background: var(--surface-2);
+    color: var(--muted);
+    font-size: 1.2rem;
+    line-height: 1;
+    cursor: pointer;
+    transition: background var(--trans-fast), border-color var(--trans-fast), color var(--trans-fast);
+}
+
+.sidebar__close:hover {
+    background: color-mix(in oklab, var(--surface-2) 70%, var(--brand) 15%);
+    border-color: color-mix(in oklab, var(--border) 55%, var(--brand) 25%);
+    color: var(--text);
+}
+
+.sidebar__close:focus-visible {
+    outline: none;
+    box-shadow: var(--focus);
+}
+
+@media (max-width: 960px) {
+    .sidebar__close {
+        display: inline-flex;
+    }
 }
 
 .sidebar__mode {
@@ -1671,11 +1713,16 @@ p  { margin: 0 0 .75rem; color: var(--text); }
 .app-sidebar .invite-button {
     width: 100%;
     align-items: stretch;
+    text-align: left;
 }
 
 .app-sidebar .invite-button > .btn {
     width: 100%;
     justify-content: center;
+}
+
+.app-sidebar .invite-feedback {
+    width: 100%;
 }
 
 .app-main {
@@ -1694,6 +1741,8 @@ p  { margin: 0 0 .75rem; color: var(--text); }
     justify-content: space-between;
     gap: 24px;
     align-items: flex-start;
+    position: relative;
+    z-index: 350;
 }
 
 .header-leading {


### PR DESCRIPTION
## Summary
- add a dedicated sidebar close control that appears on small screens and uses new styles
- lift the main header above the overlay so the toggle stays visible while the sidebar is open
- normalize invite button layout in the sidebar so the button and feedback fill the column width

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4a4f829408331b78ce3f982ae4540