### PR TITLE
Add configurable realtime WebSocket endpoint

### DIFF
--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -1,6 +1,6 @@
 // --- FILE: web/src/App.jsx ---
 import React, { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
-import { ApiError, Auth, Games, Help, Items, Personas, StoryLogs, onApiActivity } from "./api";
+import { ApiError, Auth, Games, Help, Items, Personas, StoryLogs, onApiActivity, resolveRealtimeUrl } from "./api";
 
 const EMPTY_ARRAY = Object.freeze([]);
 const EMPTY_OBJECT = Object.freeze({});
@@ -784,8 +784,7 @@ function useRealtimeConnection({ gameId, refreshGame, onGameDeleted }) {
         const connect = () => {
             if (cancelled) return;
             try {
-                const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
-                const url = `${protocol}//${window.location.host}/ws`;
+                const url = resolveRealtimeUrl("/ws");
                 const ws = new WebSocket(url);
                 socketRef.current = ws;
                 setConnectionState("connecting");


### PR DESCRIPTION
## Summary
- allow configuration of the realtime websocket base URL via Vite env vars and API base fallbacks
- update the client connection logic to reuse the shared resolver when opening realtime sockets

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4a8be6ff08331bdace3847b05a437