### PR TITLE
Point clients to production endpoints

### DIFF
--- a/server.js
+++ b/server.js
@@ -86,7 +86,7 @@ const DB_CONNECT_MAX_ATTEMPTS = Math.max(1, envNumber('MONGODB_CONNECT_MAX_ATTEM
 const DB_CONNECT_RETRY_DELAY_MS = Math.max(500, envNumber('MONGODB_CONNECT_RETRY_MS', 2000) || 2000);
 
 const SESSION_SECRET = envString('SESSION_SECRET', 'dev-secret');
-const RAW_CORS_ORIGINS = envString('CORS_ORIGINS', 'http://localhost:5173');
+const RAW_CORS_ORIGINS = envString('CORS_ORIGINS', 'https://jack-endex.darkmatterservers.com');
 const ALLOWED_ORIGINS = RAW_CORS_ORIGINS
     .split(',')
     .map((origin) => origin.trim())

--- a/vite.config.js
+++ b/vite.config.js
@@ -11,7 +11,7 @@ export default defineConfig({
         proxy: {
             // Frontend calls `/api/...` and Vite forwards to your Node API
             '/api': {
-                target: 'jack-api.darkmatterservers.com', // <- your API port
+                target: 'https://jack-api.darkmatterservers.com', // <- your API port
                 changeOrigin: true,
                 secure: false,
                 ws: true,
@@ -20,7 +20,7 @@ export default defineConfig({
             },
             // Proxy websocket connections used for real-time features in dev mode
             '/ws': {
-                target: 'ws://jack-api.darkmatterservers.com',
+                target: 'wss://jack-api.darkmatterservers.com',
                 changeOrigin: true,
                 secure: false,
                 ws: true,

--- a/web/src/api.js
+++ b/web/src/api.js
@@ -414,14 +414,16 @@ export function createApi({
 // ---- Default API instance ----
 // Adjust baseURL if your frontend is not served behind the same origin.
 // Example: baseURL: import.meta.env.VITE_API_BASE || '/api'
-const envBaseURL = (import.meta.env?.VITE_API_BASE ?? '').trim();
-const normalizedBaseURL = envBaseURL ? envBaseURL.replace(/\/$/, '') : '';
-const envRealtimeBase = (
+const DEFAULT_API_BASE = 'https://jack-api.darkmatterservers.com';
+const envBaseURLRaw = (import.meta.env?.VITE_API_BASE ?? '').trim();
+const normalizedBaseURL = (envBaseURLRaw || DEFAULT_API_BASE).replace(/\/$/, '');
+const DEFAULT_REALTIME_BASE = 'https://jack-api.darkmatterservers.com';
+const envRealtimeBaseRaw = (
     import.meta.env?.VITE_REALTIME_URL ??
     import.meta.env?.VITE_REALTIME_BASE ??
     ''
 ).trim();
-const normalizedRealtimeBase = envRealtimeBase ? envRealtimeBase.replace(/\/$/, '') : '';
+const normalizedRealtimeBase = (envRealtimeBaseRaw || DEFAULT_REALTIME_BASE).replace(/\/$/, '');
 
 function normalizeRealtimeBase(raw) {
     const value = typeof raw === 'string' ? raw.trim() : '';


### PR DESCRIPTION
## Summary
- default the web client's REST and realtime base URLs to https://jack-api.darkmatterservers.com
- proxy API and websocket traffic through the production host during Vite dev sessions
- align the server's default CORS origin with https://jack-endex.darkmatterservers.com

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4b155686c8331b6dfd4106ad1523a