### PR TITLE
Ensure Docker build installs dev dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@
 # Base image with Node.js available for all stages
 FROM node:20-slim AS base
 WORKDIR /app
-ENV NODE_ENV=production
 
 # Install all dependencies (including dev deps required for the build)
 FROM base AS deps


### PR DESCRIPTION
## Summary
- remove the production NODE_ENV from the build base image so npm ci installs dev dependencies
- keep NODE_ENV=production only in the final runtime stage to ensure the build step can access Vite

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d596f936708331922eb0a1cbc1ccd0