### PR TITLE
Fix default API and websocket configuration

### DIFF
--- a/client/src/api.js
+++ b/client/src/api.js
@@ -414,10 +414,10 @@ export function createApi({
 // ---- Default API instance ----
 // Adjust baseURL if your frontend is not served behind the same origin.
 // Example: baseURL: import.meta.env.VITE_API_BASE || '/api'
-const DEFAULT_API_BASE = 'https://jack-api.darkmatterservers.com';
+const DEFAULT_API_BASE = '';
 const envBaseURLRaw = (import.meta.env?.VITE_API_BASE ?? '').trim();
 const normalizedBaseURL = (envBaseURLRaw || DEFAULT_API_BASE).replace(/\/$/, '');
-const DEFAULT_REALTIME_BASE = 'https://jack-api.darkmatterservers.com';
+const DEFAULT_REALTIME_BASE = '';
 const envRealtimeBaseRaw = (
     import.meta.env?.VITE_REALTIME_URL ??
     import.meta.env?.VITE_REALTIME_BASE ??

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,5 +1,21 @@
 import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react' // remove if not using React
+import react from '@vitejs/plugin-react'
+
+const devApiTarget = process.env.VITE_DEV_API_TARGET || 'http://localhost:3000'
+
+function toWebSocketTarget(input) {
+    const fallback = 'ws://localhost:3000'
+    if (!input) return fallback
+    try {
+        const url = new URL(input)
+        url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:'
+        return url.toString()
+    } catch {
+        return fallback
+    }
+}
+
+const devRealtimeTarget = process.env.VITE_DEV_REALTIME_TARGET || toWebSocketTarget(devApiTarget)
 
 export default defineConfig({
     root: 'client',
@@ -15,22 +31,18 @@ export default defineConfig({
         strictPort: true,
         allowedHosts: ['jack-endex.darkmatterservers.com'],
         proxy: {
-            // Frontend calls `/api/...` and Vite forwards to your Node API
             '/api': {
-                target: 'https://jack-api.darkmatterservers.com', // <- your API port
+                target: devApiTarget,
                 changeOrigin: true,
                 secure: false,
                 ws: true,
-                // if your backend expects the path without the /api prefix, uncomment:
-                // rewrite: (path) => path.replace(/^\/api/, '')
             },
-            // Proxy websocket connections used for real-time features in dev mode
             '/ws': {
-                target: 'wss://jack-api.darkmatterservers.com',
+                target: devRealtimeTarget,
                 changeOrigin: true,
                 secure: false,
                 ws: true,
             },
-        }
-    }
+        },
+    },
 })


### PR DESCRIPTION
## Summary
- default API and realtime clients to same-origin URLs so local dev no longer targets the remote production host
- expose configurable dev proxy targets in Vite and default them to the local Express server, with automatic ws scheme conversion

## Testing
- npx eslint client/src/api.js vite.config.js

------
https://chatgpt.com/codex/tasks/task_e_68d5c180b0488331a93085509cf0c8de