### PR TITLE
Default trust proxy when secure cookies

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -3473,9 +3473,22 @@ function hash(pw, salt) {
 
 const app = express();
 
-if (TRUST_PROXY) {
-    const numeric = Number(TRUST_PROXY);
-    app.set('trust proxy', Number.isNaN(numeric) ? TRUST_PROXY : numeric);
+const resolvedTrustProxy = (() => {
+    if (TRUST_PROXY) {
+        const numeric = Number(TRUST_PROXY);
+        return Number.isNaN(numeric) ? TRUST_PROXY : numeric;
+    }
+
+    if (SESSION_COOKIE_SECURE) {
+        console.log('[session] TRUST_PROXY not set; defaulting to 1 because SESSION_COOKIE_SECURE=true.');
+        return 1;
+    }
+
+    return null;
+})();
+
+if (resolvedTrustProxy !== null && resolvedTrustProxy !== undefined) {
+    app.set('trust proxy', resolvedTrustProxy);
 }
 
 app.use(cors({


### PR DESCRIPTION
## Summary
- automatically trust the first proxy when secure session cookies are enabled and TRUST_PROXY is not set
- log when the fallback is applied so operators know why it happened

## Testing
- npm run lint (fails: existing lint errors in client sources)


------
https://chatgpt.com/codex/tasks/task_e_68d5c98bf9b08331893d11536fe6e8a8