### PR TITLE
Fix battle map drawing usability

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1524,6 +1524,18 @@ function mapClamp01(value) {
     return num;
 }
 
+function mapReadBoolean(value) {
+    if (typeof value === 'boolean') return value;
+    if (typeof value === 'number') return value !== 0;
+    if (typeof value === 'string') {
+        const normalized = value.trim().toLowerCase();
+        if (!normalized) return false;
+        if (['true', '1', 'yes', 'on'].includes(normalized)) return true;
+        if (['false', '0', 'no', 'off'].includes(normalized)) return false;
+    }
+    return false;
+}
+
 function clamp(value, min, max, fallback = min) {
     const num = Number(value);
     if (!Number.isFinite(num)) return fallback;
@@ -2012,10 +2024,10 @@ function normalizeClientMapState(map) {
         tokens,
         shapes,
         settings: {
-            allowPlayerDrawing: !!map.settings?.allowPlayerDrawing,
-            allowPlayerTokenMoves: !!map.settings?.allowPlayerTokenMoves,
+            allowPlayerDrawing: mapReadBoolean(map.settings?.allowPlayerDrawing),
+            allowPlayerTokenMoves: mapReadBoolean(map.settings?.allowPlayerTokenMoves),
         },
-        paused: !!map.paused,
+        paused: mapReadBoolean(map.paused),
         background: normalizeClientMapBackground(map.background),
         updatedAt: typeof map.updatedAt === 'string' ? map.updatedAt : null,
     };
@@ -3162,6 +3174,7 @@ function MapTab({ game, me }) {
                                     <input
                                         type="color"
                                         value={brushColor}
+                                        style={{ backgroundColor: brushColor }}
                                         onChange={(event) => {
                                             const value = event.target.value || brushColor;
                                             setBrushColor(typeof value === 'string' ? value : brushColor);
@@ -3558,6 +3571,7 @@ function MapTab({ game, me }) {
                                                             id="map-enemy-color"
                                                             type="color"
                                                             value={enemyForm.color}
+                                                            style={{ backgroundColor: enemyForm.color }}
                                                             onChange={(event) =>
                                                                 setEnemyForm((prev) => ({
                                                                     ...prev,
@@ -4328,6 +4342,7 @@ function MapTab({ game, me }) {
                                                                 <input
                                                                     type="color"
                                                                     value={shape.fill}
+                                                                    style={{ backgroundColor: shape.fill }}
                                                                     onChange={(event) => {
                                                                         const value = event.target.value || shape.fill;
                                                                         setMapState((prev) => ({
@@ -4353,6 +4368,7 @@ function MapTab({ game, me }) {
                                                                 <input
                                                                     type="color"
                                                                     value={shape.stroke}
+                                                                    style={{ backgroundColor: shape.stroke }}
                                                                     onChange={(event) => {
                                                                         const value = event.target.value || shape.stroke;
                                                                         setMapState((prev) => ({
@@ -9779,9 +9795,9 @@ function SettingsTab({ game, onUpdate, me, onDelete, onKickPlayer, onGameRefresh
     const [storyForm, setStoryForm] = useState(storyDefaults);
     const [storySaving, setStorySaving] = useState(false);
     const [mapSettings, setMapSettings] = useState(() => ({
-        allowPlayerDrawing: !!game.map?.settings?.allowPlayerDrawing,
-        allowPlayerTokenMoves: !!game.map?.settings?.allowPlayerTokenMoves,
-        paused: !!game.map?.paused,
+        allowPlayerDrawing: mapReadBoolean(game.map?.settings?.allowPlayerDrawing),
+        allowPlayerTokenMoves: mapReadBoolean(game.map?.settings?.allowPlayerTokenMoves),
+        paused: mapReadBoolean(game.map?.paused),
     }));
     const [mapSaving, setMapSaving] = useState(false);
     const [clearingDrawings, setClearingDrawings] = useState(false);
@@ -9800,9 +9816,9 @@ function SettingsTab({ game, onUpdate, me, onDelete, onKickPlayer, onGameRefresh
 
     useEffect(() => {
         setMapSettings({
-            allowPlayerDrawing: !!game.map?.settings?.allowPlayerDrawing,
-            allowPlayerTokenMoves: !!game.map?.settings?.allowPlayerTokenMoves,
-            paused: !!game.map?.paused,
+            allowPlayerDrawing: mapReadBoolean(game.map?.settings?.allowPlayerDrawing),
+            allowPlayerTokenMoves: mapReadBoolean(game.map?.settings?.allowPlayerTokenMoves),
+            paused: mapReadBoolean(game.map?.paused),
         });
     }, [
         game.id,
@@ -9847,9 +9863,9 @@ function SettingsTab({ game, onUpdate, me, onDelete, onKickPlayer, onGameRefresh
             try {
                 const updated = await Games.updateMapSettings(game.id, changes);
                 setMapSettings({
-                    allowPlayerDrawing: !!updated.settings?.allowPlayerDrawing,
-                    allowPlayerTokenMoves: !!updated.settings?.allowPlayerTokenMoves,
-                    paused: !!updated.paused,
+                    allowPlayerDrawing: mapReadBoolean(updated.settings?.allowPlayerDrawing),
+                    allowPlayerTokenMoves: mapReadBoolean(updated.settings?.allowPlayerTokenMoves),
+                    paused: mapReadBoolean(updated.paused),
                 });
                 if (typeof onGameRefresh === "function") {
                     await onGameRefresh();

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -460,13 +460,24 @@ p  { margin: 0 0 .75rem; color: var(--text); }
 }
 .color-input input[type="color"] {
     appearance: none;
-    border: none;
+    border: 1px solid rgba(148, 163, 184, 0.45);
     padding: 0;
     width: 40px;
     height: 28px;
     border-radius: var(--radius-sm);
     cursor: pointer;
-    background: none;
+    background-color: transparent;
+}
+.color-input input[type="color"]::-webkit-color-swatch-wrapper {
+    padding: 0;
+}
+.color-input input[type="color"]::-webkit-color-swatch {
+    border: none;
+    border-radius: var(--radius-sm);
+}
+.color-input input[type="color"]::-moz-color-swatch {
+    border: none;
+    border-radius: var(--radius-sm);
 }
 .color-input input[type="color"]::-webkit-color-swatch {
     border-radius: var(--radius-sm);
@@ -569,6 +580,30 @@ p  { margin: 0 0 .75rem; color: var(--text); }
 
 .map-shape--line {
     border-radius: 999px;
+}
+
+.map-shape--circle,
+.map-shape--circle .map-shape__surface,
+.map-shape--line .map-shape__surface {
+    border-radius: 999px;
+}
+
+.map-shape--diamond,
+.map-shape--triangle,
+.map-shape--cone {
+    border-radius: 0;
+}
+
+.map-shape--diamond .map-shape__surface {
+    clip-path: polygon(50% 0%, 100% 50%, 50% 100%, 0% 50%);
+}
+
+.map-shape--triangle .map-shape__surface {
+    clip-path: polygon(50% 0%, 100% 100%, 0% 100%);
+}
+
+.map-shape--cone .map-shape__surface {
+    clip-path: polygon(50% 0%, 100% 88%, 50% 100%, 0% 88%);
 }
 
 .map-shape:hover {

--- a/server/server.js
+++ b/server/server.js
@@ -405,6 +405,19 @@ function clamp01(value) {
     return num;
 }
 
+function toBoolean(value, defaultValue = false) {
+    if (typeof value === 'boolean') return value;
+    if (typeof value === 'number') return value !== 0;
+    if (typeof value === 'string') {
+        const normalized = value.trim().toLowerCase();
+        if (!normalized) return defaultValue;
+        if (['true', '1', 'yes', 'on'].includes(normalized)) return true;
+        if (['false', '0', 'no', 'off'].includes(normalized)) return false;
+    }
+    if (value === null || value === undefined) return defaultValue;
+    return Boolean(value);
+}
+
 function normalizeRotation(value) {
     const num = Number(value);
     if (!Number.isFinite(num)) return 0;
@@ -954,10 +967,10 @@ function ensureMapState(game) {
         tokens,
         shapes,
         settings: {
-            allowPlayerDrawing: !!settingsRaw.allowPlayerDrawing,
-            allowPlayerTokenMoves: !!settingsRaw.allowPlayerTokenMoves,
+            allowPlayerDrawing: toBoolean(settingsRaw.allowPlayerDrawing, false),
+            allowPlayerTokenMoves: toBoolean(settingsRaw.allowPlayerTokenMoves, false),
         },
-        paused: !!raw.paused,
+        paused: toBoolean(raw.paused, false),
         background: presentMapBackground(raw.background),
         updatedAt,
     };
@@ -991,10 +1004,10 @@ function presentMapState(map) {
         tokens,
         shapes,
         settings: {
-            allowPlayerDrawing: !!map.settings?.allowPlayerDrawing,
-            allowPlayerTokenMoves: !!map.settings?.allowPlayerTokenMoves,
+            allowPlayerDrawing: toBoolean(map.settings?.allowPlayerDrawing, false),
+            allowPlayerTokenMoves: toBoolean(map.settings?.allowPlayerTokenMoves, false),
         },
-        paused: !!map.paused,
+        paused: toBoolean(map.paused, false),
         background: presentMapBackground(map.background),
         updatedAt: typeof map.updatedAt === 'string' ? map.updatedAt : null,
     };


### PR DESCRIPTION
## Summary
- normalize battle map permissions and pause flags on both client and server so legacy string values no longer block player drawings
- refresh battle-map color pickers with visible swatches and inline styling for custom colors
- style non-rectangular battle map templates so circle, diamond, triangle, and cone shapes render correctly

## Testing
- `npm run lint` *(fails: existing lint errors unrelated to these changes)*

------
https://chatgpt.com/codex/tasks/task_e_68d5eab0408083318c891bb0d5a1eca6