### PR TITLE
Fix demon lookup in codex and battle map

### DIFF
--- a/client/src/components/DemonTab.jsx
+++ b/client/src/components/DemonTab.jsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-import { Games, Personas } from "../api";
+import { ApiError, Games, Personas } from "../api";
 import {
     ABILITY_DEFS,
     COMBAT_CATEGORY_LABELS,


### PR DESCRIPTION
## Summary
- import the ApiError class into the demon codex so persona lookup errors are handled correctly
- expand the battle map demon lookup to match roster entries by slug or name when importing details

## Testing
- npm run lint *(fails: existing lint errors about undefined helpers such as COMBAT_TIER_ORDER in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d5ef0a44d88331a00eb91e18c75456