### PR TITLE
Add reference summaries to combat and world skill tabs

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -8,6 +8,7 @@ import WorldSkillsTab from "./components/WorldSkillsTab";
 import { GearTab, ItemsTab } from "./components/ItemsGearTabs";
 import DemonTab from "./components/DemonTab";
 import { DM_NAV, PLAYER_NAV } from "./constants/navigation";
+import { BATTLE_MATH_REFERENCE } from "./constants/referenceContent";
 import {
     ABILITY_DEFS,
     ABILITY_KEY_SET,
@@ -9192,6 +9193,17 @@ function CombatSkillsTab({ game, me, onUpdate }) {
                     >
                         Demon codex
                     </button>
+                    <button
+                        type="button"
+                        role="tab"
+                        aria-selected={activePane === "reference"}
+                        className={`combat-skill-manager__tab${
+                            activePane === "reference" ? " is-active" : ""
+                        }`}
+                        onClick={() => setActivePane("reference")}
+                    >
+                        Battle Math
+                    </button>
                 </div>
                 {activePane === "library" ? (
                     <>
@@ -9307,10 +9319,93 @@ function CombatSkillsTab({ game, me, onUpdate }) {
                             </p>
                         )}
                     </>
-                ) : (
+                ) : activePane === "codex" ? (
                     <CombatSkillCodexPanel demons={demons} skills={combatSkills} />
+                ) : (
+                    <CombatSkillReferencePanel reference={BATTLE_MATH_REFERENCE} />
                 )}
             </div>
+        </div>
+    );
+}
+
+function CombatSkillReferencePanel({ reference = BATTLE_MATH_REFERENCE }) {
+    const steps = [
+        `Roll accuracy (${reference.accuracy.formula}).`,
+        `Resolve damage (${reference.damage.formula}).`,
+        "Apply weapon bonuses, weaknesses, resistances, buffs, debuffs, and critical modifiers.",
+    ];
+
+    return (
+        <div className="combat-reference stack-lg">
+            <section className="combat-reference__section">
+                <h4>Battle flow</h4>
+                <p className="text-small">{reference.overview}</p>
+                <ol className="combat-reference__list combat-reference__list--numbered">
+                    {steps.map((step, index) => (
+                        <li key={index}>{step}</li>
+                    ))}
+                </ol>
+            </section>
+
+            <section className="combat-reference__section">
+                <h4>{reference.accuracy.title}</h4>
+                <p className="combat-reference__formula">
+                    <code>{reference.accuracy.formula}</code>
+                </p>
+                <ul className="combat-reference__list">
+                    {reference.accuracy.notes.map((note, index) => (
+                        <li key={index}>{note}</li>
+                    ))}
+                </ul>
+            </section>
+
+            <section className="combat-reference__section">
+                <h4>{reference.damage.title}</h4>
+                <p className="combat-reference__formula">
+                    <code>{reference.damage.formula}</code>
+                </p>
+                <ul className="combat-reference__list">
+                    {reference.damage.notes.map((note, index) => (
+                        <li key={index}>{note}</li>
+                    ))}
+                </ul>
+            </section>
+
+            <section className="combat-reference__section">
+                <h4>Standard tiers</h4>
+                <div className="combat-reference__table-wrapper">
+                    <table className="combat-reference__table">
+                        <thead>
+                            <tr>
+                                <th>Tier</th>
+                                <th>Example</th>
+                                <th>Dice</th>
+                                <th>Ability modifier</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {reference.tiers.map((tier) => (
+                                <tr key={tier.tier}>
+                                    <th scope="row">{tier.tier}</th>
+                                    <td>{tier.example}</td>
+                                    <td>{tier.dice}</td>
+                                    <td>{tier.modifier}</td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                </div>
+            </section>
+
+            <section className="combat-reference__section">
+                <h4>Table rulings</h4>
+                <ul className="combat-reference__list">
+                    {reference.skillNotes.map((note, index) => (
+                        <li key={index}>{note}</li>
+                    ))}
+                </ul>
+            </section>
         </div>
     );
 }

--- a/client/src/components/WorldSkillsTab.jsx
+++ b/client/src/components/WorldSkillsTab.jsx
@@ -14,6 +14,7 @@ import {
     serializeCustomSkills,
     serializeSkills,
 } from "../constants/gameData";
+import { WORLD_SKILL_REFERENCE } from "../constants/referenceContent";
 import { get } from "../utils/object";
 
 import MathField from "./MathField";
@@ -618,6 +619,41 @@ function WorldSkillsTab({ game, me, onUpdate }) {
 
     return (
         <div className="col" style={{ display: "grid", gap: 16 }}>
+            <div className="card world-skill-reference">
+                <div className="world-skill-reference__header">
+                    <div>
+                        <h3>World skill rules</h3>
+                        <p className="text-muted text-small">
+                            Summarised from the Character Creation and Battle Math reference docs.
+                        </p>
+                    </div>
+                </div>
+                <p className="text-small">{WORLD_SKILL_REFERENCE.summary}</p>
+                <div className="world-skill-reference__grid">
+                    {WORLD_SKILL_REFERENCE.formulas.map((entry) => (
+                        <div key={entry.label} className="world-skill-reference__formula">
+                            <span className="text-small">{entry.label}</span>
+                            <code>{entry.formula}</code>
+                        </div>
+                    ))}
+                </div>
+                <div className="world-skill-reference__callouts">
+                    <h4>Guidelines</h4>
+                    <ul>
+                        {WORLD_SKILL_REFERENCE.guidelines.map((tip, index) => (
+                            <li key={index}>{tip}</li>
+                        ))}
+                    </ul>
+                </div>
+                <div className="world-skill-reference__callouts">
+                    <h4>Table tips</h4>
+                    <ul>
+                        {WORLD_SKILL_REFERENCE.tips.map((tip, index) => (
+                            <li key={index}>{tip}</li>
+                        ))}
+                    </ul>
+                </div>
+            </div>
             {isDM && (
                 <div className="card world-skill-manager">
                     <div className="world-skill-manager__header">

--- a/client/src/constants/referenceContent.js
+++ b/client/src/constants/referenceContent.js
@@ -1,0 +1,62 @@
+// --- FILE: client/src/constants/referenceContent.js ---
+// Reference snippets adapted from the Battlemath and Character Creation txtdocs.
+// Provides quick summaries so the UI can surface the table rules without opening the raw files.
+
+export const BATTLE_MATH_REFERENCE = Object.freeze({
+    overview:
+        "Roll Accuracy → Roll Attack → Add weapon attack or subtract enemy armor → Multiply by affinities and buffs.",
+    accuracy: Object.freeze({
+        title: "Accuracy checks",
+        formula: "1d20 + ACC − EVA",
+        notes: [
+            "Physical attacks use Accuracy against the target's Evasion.",
+            "Magical attacks use Magic Accuracy against Magic Evasion.",
+            "Ailments contest the defender's CON modifier instead of Evasion.",
+            "A 20 is a critical (+75% damage) and a 1 is a critical miss.",
+            "If a skill has a secondary effect, roll 1d20 for it during the accuracy step.",
+        ],
+    }),
+    damage: Object.freeze({
+        title: "Damage rolls",
+        formula: "(Attack roll + ATK − DEF) × Buff%",
+        notes: [
+            "Physical attacks rely on ATK versus DEF. Magical attacks use Magic Attack versus Magic Defense.",
+            "Apply weapon bonuses before multiplying buffs, weaknesses, and resistances.",
+            "Unarmed attacks deal 1d4 + STR strike damage.",
+            "Gun skills cost one bullet per hit in addition to MP/TP.",
+        ],
+    }),
+    tiers: Object.freeze([
+        { tier: "Weak", example: "Zio", dice: "1d6", modifier: "MOD" },
+        { tier: "Medium", example: "Zionga", dice: "2d8", modifier: "MOD × 2" },
+        { tier: "Heavy", example: "Ziodyne", dice: "3d12", modifier: "MOD × 3" },
+        { tier: "Severe", example: "Ziobarion", dice: "4d20", modifier: "MOD × 4" },
+    ]),
+    skillNotes: Object.freeze([
+        "Skills replace the weapon's basic attack but keep any flat attack and accuracy bonuses.",
+        "Multi-hit skills apply the ability modifier on every hit; basic attack multi-hits only add it once.",
+        "Criticals multiply the post-roll damage by 1.75. Apply buffs after resolving individual hits.",
+        "DM judgement calls the target number; 10 is considered an average difficulty.",
+    ]),
+});
+
+export const WORLD_SKILL_REFERENCE = Object.freeze({
+    summary:
+        "Skill Points (SP) fuel world skills. Spend them as soon as they are earned to train the pink-box skills on the sheet.",
+    formulas: Object.freeze([
+        { label: "HP", formula: "17 + CON + (STR ÷ 2)" },
+        { label: "MP", formula: "17 + INT + (WIS ÷ 2)" },
+        { label: "TP", formula: "7 + DEX + (CON ÷ 2)" },
+        { label: "SP", formula: "((5 + INT) × 2) + CHA" },
+    ]),
+    guidelines: Object.freeze([
+        "Always round up when applying these resource formulas and never let gains drop below 1.",
+        "SP must be spent immediately on world skills when gained; they cannot be banked.",
+        "Maximum rank equals level × 2 + 2 (minimum 4 at level 1).",
+        "Skills below the pink divider are DM-awarded or require in-game training.",
+    ]),
+    tips: Object.freeze([
+        "Keep an eye on ability modifiers—every skill adds its linked ability mod, trained ranks, and miscellaneous bonuses.",
+        "DMs can remove ranks with the take-away action if downtime or events strip training.",
+    ]),
+});

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -2823,6 +2823,15 @@ label {
 .world-skill-card__add-btn:disabled { opacity: 0.6; cursor: not-allowed; }
 .world-skill-card__plus { display: inline-grid; place-items: center; width: 44px; height: 44px; border-radius: 999px; background: color-mix(in oklab, var(--brand) 18%, transparent); color: var(--brand-700); font-size: 1.6rem; font-weight: 700; }
 .world-skill-empty { border: 1px dashed var(--border); border-radius: var(--radius); padding: 16px; display: grid; gap: 6px; align-content: start; background: var(--surface); text-align: center; color: var(--muted); }
+.world-skill-reference { display: grid; gap: 16px; }
+.world-skill-reference__grid { display: grid; gap: 12px; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); }
+.world-skill-reference__formula { display: grid; gap: 4px; padding: 12px; border: 1px solid var(--border); border-radius: var(--radius-sm); background: var(--surface-2); }
+.world-skill-reference__formula code { font-size: 0.95rem; font-weight: 600; }
+.world-skill-reference__callouts { display: grid; gap: 8px; }
+.world-skill-reference__callouts h4 { margin: 0; color: var(--text); font-weight: 600; }
+.world-skill-reference__callouts ul { margin: 0; padding-left: 18px; display: grid; gap: 4px; color: var(--muted); list-style-position: inside; }
+.world-skill-reference__header { display: flex; justify-content: space-between; align-items: flex-start; gap: 12px; flex-wrap: wrap; }
+.world-skill-reference__header h3 { margin: 0; }
 
 .combat-skill-tab .card { display: grid; gap: 16px; }
 .combat-skill-manager__header { display: flex; justify-content: space-between; align-items: flex-start; gap: 12px; flex-wrap: wrap; }
@@ -2852,6 +2861,16 @@ label {
 .combat-skill-editor__actions { display: flex; gap: 8px; flex-wrap: wrap; justify-content: flex-end; }
 .combat-skill-manager__nav { display: flex; gap: 8px; flex-wrap: wrap; margin-top: 12px; }
 .combat-skill-manager__tab { border: 1px solid var(--border); border-radius: var(--radius-sm); background: var(--surface-2); color: var(--muted); font-weight: 600; padding: 8px 14px; cursor: pointer; transition: border-color var(--trans-fast), background var(--trans-fast), color var(--trans-fast), box-shadow var(--trans-fast); }
+.combat-reference { display: grid; gap: 18px; }
+.combat-reference__section { display: grid; gap: 8px; }
+.combat-reference__formula code { font-weight: 600; font-size: 0.95rem; }
+.combat-reference__list { margin: 0; padding-left: 18px; display: grid; gap: 6px; color: var(--muted); list-style-position: inside; }
+.combat-reference__list--numbered { list-style: decimal; }
+.combat-reference__table-wrapper { overflow-x: auto; }
+.combat-reference__table { width: 100%; border-collapse: collapse; }
+.combat-reference__table th,
+.combat-reference__table td { border: 1px solid var(--border); padding: 8px; text-align: left; }
+.combat-reference__table th { background: var(--surface-2); font-weight: 600; }
 .combat-skill-manager__tab.is-active { border-color: var(--brand); color: var(--text); background: var(--surface); box-shadow: var(--focus); }
 .combat-skill-manager__tab:focus-visible { outline: none; border-color: var(--brand); box-shadow: var(--focus); }
 .combat-skill-manager__tab:disabled { opacity: 0.6; cursor: default; }


### PR DESCRIPTION
## Summary
- add a reusable referenceContent module sourced from the Battlemath and rules txtdocs
- surface a Battle Math quick reference panel alongside the combat skill library and codex
- introduce a world skill rules card with resource formulas and spending guidelines
- style the new reference sections to match existing cards

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5eff1d91883319719843cf645ea21