### PR TITLE
Improve demon lookup bot reliability

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint .",
     "preview": "vite preview --host --port 5173",
     "start": "node server/server.js",
+    "bot:demon": "node server/bot/demonLookupBot.js",
     "update:demons": "node scripts/convert-demons.js"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- add an npm script for launching the demon lookup Discord bot
- retry MongoDB connections for the bot before failing startup so transient outages do not stop it
- add graceful shutdown and error handlers to keep the bot process running reliably

## Testing
- npm run lint *(fails: existing client lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d5f31356608331b06581a61fc1f457