### PR TITLE
Fix world skills tab dependencies

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -17,6 +17,7 @@ import {
     COMBAT_CATEGORY_OPTIONS,
     COMBAT_SKILL_SORT_OPTIONS,
     COMBAT_SKILL_SORTERS,
+    COMBAT_TIER_ORDER,
     COMBAT_TIER_INFO,
     COMBAT_TIER_LABELS,
     CONCEPT_PROMPTS,
@@ -27,13 +28,9 @@ import {
     WORLD_SKILL_SORTERS,
     abilityModifier,
     clampNonNegative,
-    collectResistanceTerms,
     computeCombatSkillDamage,
-    createAbilityMap,
     formatModifier,
-    formatResistanceList,
     getDemonSkillList,
-    getResistanceCount,
     makeCustomSkillId,
     NEW_COMBAT_SKILL_ID,
     NEW_WORLD_SKILL_ID,
@@ -41,13 +38,11 @@ import {
     normalizeCombatSkillDefs,
     normalizeCustomSkills,
     normalizeWorldSkillDefs,
-    resolveAbilityState,
     ROLE_ARCHETYPES,
     SAVE_DEFS,
-    serializeCustomSkills,
-    serializeSkills,
 } from "./constants/gameData";
 import { EMPTY_ARRAY, EMPTY_OBJECT } from "./utils/constants";
+import { deepClone, normalizeCharacter, normalizeSkills } from "./utils/character";
 import { get } from "./utils/object";
 
 const DEMON_IMAGE_FALLBACK_BASES = [
@@ -7267,75 +7262,6 @@ function buildCharacterFromWizard(state, base, worldSkills = DEFAULT_WORLD_SKILL
     return merged;
 }
 
-function normalizeCharacter(raw, worldSkills = DEFAULT_WORLD_SKILLS) {
-    if (!raw || typeof raw !== 'object') {
-        return {
-            name: '',
-            profile: {},
-            stats: {},
-            resources: { useTP: false },
-            skills: normalizeSkills({}, worldSkills),
-            customSkills: [],
-        };
-    }
-    const clone = deepClone(raw);
-    clone.name = typeof clone.name === 'string' ? clone.name : '';
-    clone.profile = clone.profile && typeof clone.profile === 'object' ? { ...clone.profile } : {};
-    clone.stats = clone.stats && typeof clone.stats === 'object' ? { ...clone.stats } : {};
-    clone.resources = clone.resources && typeof clone.resources === 'object' ? { ...clone.resources } : {};
-    if (clone.resources.useTP === undefined) {
-        clone.resources.useTP = !!clone.resources.tp && !clone.resources.mp;
-    } else {
-        clone.resources.useTP = !!clone.resources.useTP;
-    }
-    const skillSource =
-        clone.skills && typeof clone.skills === 'object' && !Array.isArray(clone.skills)
-            ? { ...clone.skills }
-            : {};
-    const embeddedCustom = [];
-    if (Array.isArray(skillSource.customSkills)) embeddedCustom.push(...skillSource.customSkills);
-    if (Array.isArray(skillSource._custom)) embeddedCustom.push(...skillSource._custom);
-    delete skillSource.customSkills;
-    delete skillSource._custom;
-    const demoted = [];
-    for (const [key, value] of Object.entries(skillSource)) {
-        if (!value || typeof value !== 'object' || Array.isArray(value)) continue;
-        const label = typeof value.label === 'string' ? value.label.trim() : '';
-        const abilityRaw = typeof value.ability === 'string' ? value.ability.trim().toUpperCase() : '';
-        if (label && ABILITY_KEY_SET.has(abilityRaw)) {
-            demoted.push({
-                id: key,
-                label,
-                ability: abilityRaw,
-                ranks: value.ranks,
-                misc: value.misc,
-            });
-            delete skillSource[key];
-        }
-    }
-    clone.skills = normalizeSkills(skillSource, worldSkills);
-    const rawCustom = clone.customSkills ?? [...embeddedCustom, ...demoted];
-    clone.customSkills = normalizeCustomSkills(rawCustom);
-    return clone;
-}
-
-function normalizeSkills(raw, worldSkills = DEFAULT_WORLD_SKILLS) {
-    const out = {};
-    if (raw && typeof raw === 'object' && !Array.isArray(raw)) {
-        for (const [key, value] of Object.entries(raw)) {
-            if (!value || typeof value !== 'object' || Array.isArray(value)) continue;
-            const ranks = clampNonNegative(value.ranks);
-            const miscRaw = Number(value.misc);
-            const misc = Number.isFinite(miscRaw) ? miscRaw : 0;
-            out[key] = { ranks, misc };
-        }
-    }
-    for (const skill of worldSkills) {
-        if (!out[skill.key]) out[skill.key] = { ranks: 0, misc: 0 };
-    }
-    return out;
-}
-
 // ---------- Party ----------
 function Party({ game, selectedPlayerId, onSelectPlayer, mode = "player", currentUserId }) {
     const realtime = useContext(RealtimeContext);
@@ -10694,7 +10620,4 @@ function SettingsTab({ game, onUpdate, me, onDelete, onKickPlayer, onGameRefresh
     );
 }
 // ---------- Utils ----------
-function deepClone(x) {
-    if (typeof structuredClone === "function") return structuredClone(x);
-    return JSON.parse(JSON.stringify(x));
-}
+

--- a/client/src/components/WorldSkillsTab.jsx
+++ b/client/src/components/WorldSkillsTab.jsx
@@ -5,9 +5,12 @@ import {
     ABILITY_DEFS,
     ABILITY_KEY_SET,
     NEW_WORLD_SKILL_ID,
+    SAVE_DEFS,
     WORLD_SKILL_SORT_OPTIONS,
     WORLD_SKILL_SORTERS,
+    abilityModifier,
     clampNonNegative,
+    formatModifier,
     makeCustomSkillId,
     normalizeCustomSkills,
     normalizeWorldSkillDefs,
@@ -16,6 +19,7 @@ import {
 } from "../constants/gameData";
 import { WORLD_SKILL_REFERENCE } from "../constants/referenceContent";
 import { get } from "../utils/object";
+import { deepClone, normalizeCharacter, normalizeSkills } from "../utils/character";
 
 import MathField from "./MathField";
 

--- a/client/src/utils/character.js
+++ b/client/src/utils/character.js
@@ -1,0 +1,87 @@
+import {
+    ABILITY_KEY_SET,
+    DEFAULT_WORLD_SKILLS,
+    clampNonNegative,
+    normalizeCustomSkills,
+} from "../constants/gameData";
+
+export function deepClone(value) {
+    if (typeof structuredClone === "function") return structuredClone(value);
+    return JSON.parse(JSON.stringify(value));
+}
+
+export function normalizeSkills(raw, worldSkills = DEFAULT_WORLD_SKILLS) {
+    const out = {};
+    if (raw && typeof raw === "object" && !Array.isArray(raw)) {
+        for (const [key, value] of Object.entries(raw)) {
+            if (!value || typeof value !== "object" || Array.isArray(value)) continue;
+            const ranks = clampNonNegative(value.ranks);
+            const miscRaw = Number(value.misc);
+            const misc = Number.isFinite(miscRaw) ? miscRaw : 0;
+            out[key] = { ranks, misc };
+        }
+    }
+    for (const skill of worldSkills) {
+        if (!out[skill.key]) out[skill.key] = { ranks: 0, misc: 0 };
+    }
+    return out;
+}
+
+export function normalizeCharacter(raw, worldSkills = DEFAULT_WORLD_SKILLS) {
+    if (!raw || typeof raw !== "object") {
+        return {
+            name: "",
+            profile: {},
+            stats: {},
+            resources: { useTP: false },
+            skills: normalizeSkills({}, worldSkills),
+            customSkills: [],
+        };
+    }
+
+    const clone = deepClone(raw);
+    clone.name = typeof clone.name === "string" ? clone.name : "";
+    clone.profile = clone.profile && typeof clone.profile === "object" ? { ...clone.profile } : {};
+    clone.stats = clone.stats && typeof clone.stats === "object" ? { ...clone.stats } : {};
+    clone.resources = clone.resources && typeof clone.resources === "object" ? { ...clone.resources } : {};
+
+    if (clone.resources.useTP === undefined) {
+        clone.resources.useTP = !!clone.resources.tp && !clone.resources.mp;
+    } else {
+        clone.resources.useTP = !!clone.resources.useTP;
+    }
+
+    const skillSource =
+        clone.skills && typeof clone.skills === "object" && !Array.isArray(clone.skills)
+            ? { ...clone.skills }
+            : {};
+
+    const embeddedCustom = [];
+    if (Array.isArray(skillSource.customSkills)) embeddedCustom.push(...skillSource.customSkills);
+    if (Array.isArray(skillSource._custom)) embeddedCustom.push(...skillSource._custom);
+    delete skillSource.customSkills;
+    delete skillSource._custom;
+
+    const demoted = [];
+    for (const [key, value] of Object.entries(skillSource)) {
+        if (!value || typeof value !== "object" || Array.isArray(value)) continue;
+        const label = typeof value.label === "string" ? value.label.trim() : "";
+        const abilityRaw = typeof value.ability === "string" ? value.ability.trim().toUpperCase() : "";
+        if (label && ABILITY_KEY_SET.has(abilityRaw)) {
+            demoted.push({
+                id: key,
+                label,
+                ability: abilityRaw,
+                ranks: value.ranks,
+                misc: value.misc,
+            });
+            delete skillSource[key];
+        }
+    }
+
+    clone.skills = normalizeSkills(skillSource, worldSkills);
+    const rawCustom = clone.customSkills ?? [...embeddedCustom, ...demoted];
+    clone.customSkills = normalizeCustomSkills(rawCustom);
+
+    return clone;
+}


### PR DESCRIPTION
## Summary
- add shared character utility helpers for cloning and skill normalization
- update App to consume the shared helpers and clean unused imports
- repair WorldSkillsTab imports so ability data and save calculations work without runtime errors

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5fb9c5cfc8331804e988878caf2ec