### PR TITLE
Clear user sessions during graceful shutdown

### DIFF
--- a/server/lib/mongoSessionStore.js
+++ b/server/lib/mongoSessionStore.js
@@ -174,4 +174,14 @@ export default class MongoSessionStore extends session.Store {
             callback(err);
         }
     }
+
+    async clear(callback = () => {}) {
+        try {
+            const collection = await this._getCollection();
+            await collection.deleteMany({});
+            callback(null);
+        } catch (err) {
+            callback(err);
+        }
+    }
 }

--- a/server/server.js
+++ b/server/server.js
@@ -3537,6 +3537,7 @@ const sessionStore = new MongoSessionStore({
 });
 
 let sessionStoreClosed = false;
+let sessionsCleared = false;
 async function closeSessionStore() {
     if (sessionStoreClosed) return;
     sessionStoreClosed = true;
@@ -3545,6 +3546,17 @@ async function closeSessionStore() {
         console.log('[session] Session store closed.');
     } catch (err) {
         console.warn('[session] Failed to close session store:', err);
+    }
+}
+
+async function logoutAllUsers() {
+    if (sessionsCleared) return;
+    sessionsCleared = true;
+    try {
+        await sessionStore.clear();
+        console.log('[session] Cleared all active sessions.');
+    } catch (err) {
+        console.warn('[session] Failed to clear active sessions during shutdown:', err);
     }
 }
 
@@ -5755,6 +5767,8 @@ async function shutdownServer({ signal = null, exitCode = 0 } = {}) {
         clearPersonaRequests();
         clearPendingTrades();
         stopAllStoryWatchers();
+
+        await logoutAllUsers();
 
         try {
             await closeWebSocketServer();


### PR DESCRIPTION
## Summary
- add a clear helper to the Mongo session store to delete all sessions
- invoke the new helper during graceful shutdown to invalidate active logins

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d696daec6c8331bff71bf6031e0ca7