### PR TITLE
Hide sidebar toggle button on desktop layouts

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1265,6 +1265,8 @@ function GameView({
                                     aria-expanded={sidebarVisible}
                                     aria-controls="game-sidebar"
                                     title={sidebarOpen ? "Hide navigation" : "Show navigation"}
+                                    hidden={isDesktop}
+                                    aria-hidden={isDesktop}
                                 >
                                     <span className="sidebar-toggle__icon" aria-hidden>
                                         ☰


### PR DESCRIPTION
## Summary
- hide the sidebar toggle control on desktop layouts by leveraging the existing desktop breakpoint flag

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d69e0917d88331accd7fb037975f05