### PR TITLE
Revamp default world skills and reference guide

### DIFF
--- a/client/src/components/WorldSkillsTab.jsx
+++ b/client/src/components/WorldSkillsTab.jsx
@@ -649,6 +649,39 @@ function WorldSkillsTab({ game, me, onUpdate }) {
                         ))}
                     </ul>
                 </div>
+                {WORLD_SKILL_REFERENCE.disciplines?.length > 0 && (
+                    <div className="world-skill-reference__abilities">
+                        <h4>Core disciplines</h4>
+                        <div className="world-skill-reference__abilities-grid">
+                            {WORLD_SKILL_REFERENCE.disciplines.map((group) => (
+                                <div
+                                    key={group.ability}
+                                    className="world-skill-reference__ability"
+                                >
+                                    <div className="world-skill-reference__ability-header">
+                                        <span className="pill light">{group.ability}</span>
+                                        <strong>{group.label}</strong>
+                                    </div>
+                                    {group.summary && (
+                                        <p className="text-muted text-small">
+                                            {group.summary}
+                                        </p>
+                                    )}
+                                    <ul>
+                                        {group.skills.map((skill) => (
+                                            <li key={skill.key}>
+                                                <strong>{skill.label}</strong>
+                                                <span className="text-small">
+                                                    {skill.summary}
+                                                </span>
+                                            </li>
+                                        ))}
+                                    </ul>
+                                </div>
+                            ))}
+                        </div>
+                    </div>
+                )}
                 <div className="world-skill-reference__callouts">
                     <h4>Table tips</h4>
                     <ul>

--- a/client/src/constants/gameData.js
+++ b/client/src/constants/gameData.js
@@ -1,4 +1,8 @@
 import { EMPTY_ARRAY } from "../utils/constants";
+import {
+    DEFAULT_WORLD_SKILL_DEFS,
+    DEFAULT_WORLD_SKILLS as SHARED_WORLD_SKILLS,
+} from "@shared/worldSkills.js";
 
 export const ABILITY_DEFS = [
     {
@@ -250,40 +254,8 @@ export const CONCEPT_PROMPTS = Object.freeze([
     },
 ]);
 
-export const DEFAULT_WORLD_SKILLS = [
-    { key: "balance", label: "Balance", ability: "DEX" },
-    { key: "bluff", label: "Bluff", ability: "CHA" },
-    { key: "climb", label: "Climb", ability: "STR" },
-    { key: "concentration", label: "Concentration", ability: "CON" },
-    { key: "craftGeneral", label: "Craft (General)", ability: "INT" },
-    { key: "craftKnowledge", label: "Craft (Knowledge)", ability: "INT" },
-    { key: "craftMagic", label: "Craft (Magic)", ability: "INT" },
-    { key: "diplomacy", label: "Diplomacy", ability: "CHA" },
-    { key: "disableDevice", label: "Disable Device", ability: "DEX" },
-    { key: "disguise", label: "Disguise", ability: "CHA" },
-    { key: "escapeArtist", label: "Escape Artist", ability: "DEX" },
-    { key: "gatherInformation", label: "Gather Information", ability: "CHA" },
-    { key: "handleAnimal", label: "Handle Animal", ability: "CHA" },
-    { key: "heal", label: "Heal", ability: "WIS" },
-    { key: "hide", label: "Hide", ability: "DEX" },
-    { key: "intimidate", label: "Intimidate", ability: "CHA" },
-    { key: "jump", label: "Jump", ability: "STR" },
-    { key: "knowledgeArcana", label: "Knowledge (Arcana)", ability: "INT" },
-    { key: "knowledgeReligion", label: "Knowledge (Religion)", ability: "INT" },
-    { key: "knowledgePlanes", label: "Knowledge (The Planes)", ability: "INT" },
-    { key: "listen", label: "Listen", ability: "WIS" },
-    { key: "moveSilently", label: "Move Silently", ability: "DEX" },
-    { key: "negotiation", label: "Negotiation", ability: "CHA" },
-    { key: "perform", label: "Perform", ability: "CHA" },
-    { key: "ride", label: "Ride", ability: "DEX" },
-    { key: "senseMotive", label: "Sense Motive", ability: "WIS" },
-    { key: "sleightOfHand", label: "Sleight of Hand", ability: "DEX" },
-    { key: "spellcraft", label: "Spellcraft", ability: "INT" },
-    { key: "spot", label: "Spot", ability: "WIS" },
-    { key: "survival", label: "Survival", ability: "WIS" },
-    { key: "swim", label: "Swim", ability: "STR" },
-    { key: "useRope", label: "Use Rope", ability: "DEX" },
-];
+export const DEFAULT_WORLD_SKILLS = SHARED_WORLD_SKILLS;
+export { DEFAULT_WORLD_SKILL_DEFS };
 
 export const ABILITY_KEY_SET = new Set(ABILITY_DEFS.map((ability) => ability.key));
 export const NEW_WORLD_SKILL_ID = "__new_world_skill__";

--- a/client/src/constants/referenceContent.js
+++ b/client/src/constants/referenceContent.js
@@ -2,6 +2,28 @@
 // Reference snippets adapted from the Battlemath and Character Creation txtdocs.
 // Provides quick summaries so the UI can surface the table rules without opening the raw files.
 
+import { DEFAULT_WORLD_SKILL_DEFS } from "@shared/worldSkills.js";
+import { ABILITY_DEFS } from "./gameData";
+
+const WORLD_SKILL_DISCIPLINES = Object.freeze(
+    ABILITY_DEFS.map((ability) => {
+        const skills = DEFAULT_WORLD_SKILL_DEFS.filter(
+            (skill) => skill.ability === ability.key
+        ).map((skill) => ({
+            key: skill.key,
+            label: skill.label,
+            summary: skill.summary,
+        }));
+        if (skills.length === 0) return null;
+        return Object.freeze({
+            ability: ability.key,
+            label: ability.label,
+            summary: ability.summary,
+            skills: Object.freeze(skills),
+        });
+    }).filter(Boolean)
+);
+
 export const BATTLE_MATH_REFERENCE = Object.freeze({
     overview:
         "Roll Accuracy → Roll Attack → Add weapon attack or subtract enemy armor → Multiply by affinities and buffs.",
@@ -42,7 +64,7 @@ export const BATTLE_MATH_REFERENCE = Object.freeze({
 
 export const WORLD_SKILL_REFERENCE = Object.freeze({
     summary:
-        "Skill Points (SP) fuel world skills. Spend them as soon as they are earned to train the pink-box skills on the sheet.",
+        "Skill Points (SP) fuel world skills. Spend them immediately to train the pink-box disciplines listed on the character sheet.",
     formulas: Object.freeze([
         { label: "HP", formula: "17 + CON + (STR ÷ 2)" },
         { label: "MP", formula: "17 + INT + (WIS ÷ 2)" },
@@ -59,4 +81,5 @@ export const WORLD_SKILL_REFERENCE = Object.freeze({
         "Keep an eye on ability modifiers—every skill adds its linked ability mod, trained ranks, and miscellaneous bonuses.",
         "DMs can remove ranks with the take-away action if downtime or events strip training.",
     ]),
+    disciplines: Object.freeze(WORLD_SKILL_DISCIPLINES),
 });

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -3010,6 +3010,13 @@ label {
 .world-skill-reference__callouts ul { margin: 0; padding-left: 18px; display: grid; gap: 4px; color: var(--muted); list-style-position: inside; }
 .world-skill-reference__header { display: flex; justify-content: space-between; align-items: flex-start; gap: 12px; flex-wrap: wrap; }
 .world-skill-reference__header h3 { margin: 0; }
+.world-skill-reference__abilities { display: grid; gap: 12px; }
+.world-skill-reference__abilities-grid { display: grid; gap: 12px; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); }
+.world-skill-reference__ability { display: grid; gap: 8px; padding: 14px; border: 1px solid var(--border); border-radius: var(--radius-sm); background: var(--surface-2); }
+.world-skill-reference__ability-header { display: flex; justify-content: space-between; align-items: center; gap: 8px; }
+.world-skill-reference__ability ul { margin: 0; padding-left: 18px; display: grid; gap: 4px; list-style-position: inside; color: var(--muted); }
+.world-skill-reference__ability li { display: grid; gap: 2px; }
+.world-skill-reference__ability li strong { color: var(--text); }
 
 .combat-skill-tab .card { display: grid; gap: 16px; }
 .combat-skill-manager__header { display: flex; justify-content: space-between; align-items: flex-start; gap: 12px; flex-wrap: wrap; }

--- a/server/server.js
+++ b/server/server.js
@@ -21,6 +21,7 @@ import Demon from './models/Demon.js';
 import Item from './models/Item.js';
 import { loadDemonEntries } from './lib/demonImport.js';
 import { loadItemEntries, parseHealingEffect } from './lib/itemImport.js';
+import { DEFAULT_WORLD_SKILLS } from '../shared/worldSkills.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const PROJECT_ROOT = path.resolve(__dirname, '..');
@@ -1269,40 +1270,6 @@ function convertLegacyStats(raw) {
     return normalizeAbilityScores(mapped);
 }
 
-const DEFAULT_WORLD_SKILLS = [
-    { id: 'balance', key: 'balance', label: 'Balance', ability: 'DEX' },
-    { id: 'bluff', key: 'bluff', label: 'Bluff', ability: 'CHA' },
-    { id: 'climb', key: 'climb', label: 'Climb', ability: 'STR' },
-    { id: 'concentration', key: 'concentration', label: 'Concentration', ability: 'CON' },
-    { id: 'craftGeneral', key: 'craftGeneral', label: 'Craft (General)', ability: 'INT' },
-    { id: 'craftKnowledge', key: 'craftKnowledge', label: 'Craft (Knowledge)', ability: 'INT' },
-    { id: 'craftMagic', key: 'craftMagic', label: 'Craft (Magic)', ability: 'INT' },
-    { id: 'diplomacy', key: 'diplomacy', label: 'Diplomacy', ability: 'CHA' },
-    { id: 'disableDevice', key: 'disableDevice', label: 'Disable Device', ability: 'DEX' },
-    { id: 'disguise', key: 'disguise', label: 'Disguise', ability: 'CHA' },
-    { id: 'escapeArtist', key: 'escapeArtist', label: 'Escape Artist', ability: 'DEX' },
-    { id: 'gatherInformation', key: 'gatherInformation', label: 'Gather Information', ability: 'CHA' },
-    { id: 'handleAnimal', key: 'handleAnimal', label: 'Handle Animal', ability: 'CHA' },
-    { id: 'heal', key: 'heal', label: 'Heal', ability: 'WIS' },
-    { id: 'hide', key: 'hide', label: 'Hide', ability: 'DEX' },
-    { id: 'intimidate', key: 'intimidate', label: 'Intimidate', ability: 'CHA' },
-    { id: 'jump', key: 'jump', label: 'Jump', ability: 'STR' },
-    { id: 'knowledgeArcana', key: 'knowledgeArcana', label: 'Knowledge (Arcana)', ability: 'INT' },
-    { id: 'knowledgeReligion', key: 'knowledgeReligion', label: 'Knowledge (Religion)', ability: 'INT' },
-    { id: 'knowledgePlanes', key: 'knowledgePlanes', label: 'Knowledge (The Planes)', ability: 'INT' },
-    { id: 'listen', key: 'listen', label: 'Listen', ability: 'WIS' },
-    { id: 'moveSilently', key: 'moveSilently', label: 'Move Silently', ability: 'DEX' },
-    { id: 'negotiation', key: 'negotiation', label: 'Negotiation', ability: 'CHA' },
-    { id: 'perform', key: 'perform', label: 'Perform', ability: 'CHA' },
-    { id: 'ride', key: 'ride', label: 'Ride', ability: 'DEX' },
-    { id: 'senseMotive', key: 'senseMotive', label: 'Sense Motive', ability: 'WIS' },
-    { id: 'sleightOfHand', key: 'sleightOfHand', label: 'Sleight of Hand', ability: 'DEX' },
-    { id: 'spellcraft', key: 'spellcraft', label: 'Spellcraft', ability: 'INT' },
-    { id: 'spot', key: 'spot', label: 'Spot', ability: 'WIS' },
-    { id: 'survival', key: 'survival', label: 'Survival', ability: 'WIS' },
-    { id: 'swim', key: 'swim', label: 'Swim', ability: 'STR' },
-    { id: 'useRope', key: 'useRope', label: 'Use Rope', ability: 'DEX' },
-];
 
 function slugifyWorldSkillLabel(label) {
     const base = label

--- a/shared/worldSkills.js
+++ b/shared/worldSkills.js
@@ -1,0 +1,157 @@
+export const DEFAULT_WORLD_SKILL_DEFS = Object.freeze([
+    Object.freeze({
+        key: 'athletics',
+        label: 'Athletics',
+        ability: 'STR',
+        summary: 'Climb, vault, swim, or sprint through obstacles with raw muscle.',
+    }),
+    Object.freeze({
+        key: 'bruteForce',
+        label: 'Brute Force',
+        ability: 'STR',
+        summary: 'Smash barriers, force doors, or bend metal with overwhelming strength.',
+    }),
+    Object.freeze({
+        key: 'grapples',
+        label: 'Grapples & Holds',
+        ability: 'STR',
+        summary: 'Tackle foes, restrain targets, or drag allies out of danger.',
+    }),
+    Object.freeze({
+        key: 'powerlifting',
+        label: 'Powerlifting',
+        ability: 'STR',
+        summary: 'Carry heavy loads, brace collapsing structures, or hold gates shut.',
+    }),
+    Object.freeze({
+        key: 'acrobatics',
+        label: 'Acrobatics',
+        ability: 'DEX',
+        summary: 'Keep balance on tight ledges, tumble past hazards, or weave through fire.',
+    }),
+    Object.freeze({
+        key: 'stealth',
+        label: 'Stealth',
+        ability: 'DEX',
+        summary: 'Slip through shadows, tail suspects, or disappear into a crowd.',
+    }),
+    Object.freeze({
+        key: 'larceny',
+        label: 'Larceny',
+        ability: 'DEX',
+        summary: 'Pick locks, disable alarms, or lift an item without being noticed.',
+    }),
+    Object.freeze({
+        key: 'marksmanship',
+        label: 'Marksmanship',
+        ability: 'DEX',
+        summary: 'Line up impossible shots, ricochet bullets, or control suppressive fire.',
+    }),
+    Object.freeze({
+        key: 'endurance',
+        label: 'Endurance',
+        ability: 'CON',
+        summary: 'March for hours, hold your breath, or keep running through exhaustion.',
+    }),
+    Object.freeze({
+        key: 'fortitude',
+        label: 'Fortitude',
+        ability: 'CON',
+        summary: 'Shake off toxins, diseases, or the crushing pressure of deep dives.',
+    }),
+    Object.freeze({
+        key: 'grit',
+        label: 'Grit',
+        ability: 'CON',
+        summary: 'Push through injuries, ignore broken bones, or keep fighting when bleeding out.',
+    }),
+    Object.freeze({
+        key: 'hardiness',
+        label: 'Hardiness',
+        ability: 'CON',
+        summary: 'Endure freezing nights, scorching deserts, or radiation-soaked ruins.',
+    }),
+    Object.freeze({
+        key: 'academics',
+        label: 'Academics',
+        ability: 'INT',
+        summary: 'Recall formal education, decode research papers, or ace complex exams.',
+    }),
+    Object.freeze({
+        key: 'arcana',
+        label: 'Arcana',
+        ability: 'INT',
+        summary: 'Analyse rituals, identify spell formulae, or recall demon lineages.',
+    }),
+    Object.freeze({
+        key: 'engineering',
+        label: 'Engineering',
+        ability: 'INT',
+        summary: 'Build gadgets, jury-rig machinery, or hack together battlefield tools.',
+    }),
+    Object.freeze({
+        key: 'strategy',
+        label: 'Strategy',
+        ability: 'INT',
+        summary: 'Plan assaults, out-think rival tacticians, or solve multi-step puzzles.',
+    }),
+    Object.freeze({
+        key: 'awareness',
+        label: 'Awareness',
+        ability: 'WIS',
+        summary: 'Spot ambushes, hear whispered plots, or sense magical auras.',
+    }),
+    Object.freeze({
+        key: 'insight',
+        label: 'Insight',
+        ability: 'WIS',
+        summary: 'Read motives, detect lies, or intuit a demon’s mood before it speaks.',
+    }),
+    Object.freeze({
+        key: 'medicine',
+        label: 'Medicine',
+        ability: 'WIS',
+        summary: 'Staunch bleeding, perform field surgery, or diagnose occult afflictions.',
+    }),
+    Object.freeze({
+        key: 'survival',
+        label: 'Survival',
+        ability: 'WIS',
+        summary: 'Track prey, forage safe food, or navigate wild lands without maps.',
+    }),
+    Object.freeze({
+        key: 'negotiation',
+        label: 'Negotiation',
+        ability: 'CHA',
+        summary: 'Broker truces, haggle with demons, or charm bureaucrats into helping.',
+    }),
+    Object.freeze({
+        key: 'deception',
+        label: 'Deception',
+        ability: 'CHA',
+        summary: 'Maintain a cover story, forge documents, or bluff through high stakes.',
+    }),
+    Object.freeze({
+        key: 'performance',
+        label: 'Performance',
+        ability: 'CHA',
+        summary: 'Rally crowds, keep morale high, or distract foes with a show.',
+    }),
+    Object.freeze({
+        key: 'streetwise',
+        label: 'Streetwise',
+        ability: 'CHA',
+        summary: 'Leverage contacts, gather rumours, or navigate underworld etiquette.',
+    }),
+]);
+
+export const DEFAULT_WORLD_SKILLS = Object.freeze(
+    DEFAULT_WORLD_SKILL_DEFS.map((skill) =>
+        Object.freeze({
+            id: skill.key,
+            key: skill.key,
+            label: skill.label,
+            ability: skill.ability,
+        })
+    )
+);

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,5 +1,7 @@
 import {defineConfig} from 'vite'
 import react from '@vitejs/plugin-react'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 const devApiTarget = process.env.VITE_DEV_API_TARGET || 'http://localhost:3000'
 
@@ -17,6 +19,8 @@ function toWebSocketTarget(input) {
 
 const devRealtimeTarget = process.env.VITE_DEV_REALTIME_TARGET || toWebSocketTarget(devApiTarget)
 
+const projectRootDir = path.dirname(fileURLToPath(import.meta.url))
+
 export default defineConfig({
     root: 'client',
     publicDir: '../public',
@@ -25,11 +29,19 @@ export default defineConfig({
         emptyOutDir: true,
     },
     plugins: [react()],
+    resolve: {
+        alias: {
+            '@shared': path.resolve(projectRootDir, 'shared'),
+        },
+    },
     server: {
         host: true,
         port: 5173,
         strictPort: true,
         allowedHosts: ['jack-endex.darkmatterservers.com'],
+        fs: {
+            allow: [projectRootDir],
+        },
         proxy: {
             '/api': {
                 target: devApiTarget,


### PR DESCRIPTION
## Summary
- replace the legacy d20-style skill list with a modernised set of world skill disciplines defined in a shared module
- surface the new discipline breakdown in the world skills reference card and polish its styling for quick table use
- update the server and build tooling to consume the shared definitions and allow cross-package imports

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d6a0b37c2c83319033ab6f8732f3a8