### PR TITLE
Add demon fusion planner and offline codex fallback

### DIFF
--- a/client/src/api.js
+++ b/client/src/api.js
@@ -698,6 +698,7 @@ export const Help = {
 };
 
 export const Personas = {
+    list: (params) => api('/api/personas', { query: params, cache: 5000 }),
     search: (q) => api('/api/personas/search', { query: { q }, cache: 5000 }),
     get: (slug) => api(`/api/personas/${encodeURIComponent(slug)}`, { cache: 5000 }),
 };

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -3124,7 +3124,171 @@ label {
 .demon-editor__preview-stats { display: flex; flex-wrap: wrap; gap: 6px; }
 .demon-editor__preview-resists { display: grid; gap: 4px; }
 
-.demon-fusion { display: grid; gap: 8px; padding: 16px; border: 1px dashed var(--border); border-radius: var(--radius); background: color-mix(in oklab, var(--brand) 8%, transparent); }
+.demon-fusion {
+    display: grid;
+    gap: 16px;
+    padding: 16px;
+    border-radius: var(--radius);
+    border: 1px solid color-mix(in oklab, var(--brand) 18%, var(--border));
+    background: color-mix(in oklab, var(--brand) 6%, transparent);
+}
+
+.demon-fusion__intro { display: grid; gap: 4px; }
+
+.demon-fusion__grid {
+    display: grid;
+    gap: 16px;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.demon-fusion__slot,
+.demon-fusion__summary {
+    display: grid;
+    gap: 12px;
+    padding: 16px;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow-sm);
+}
+
+.demon-fusion__slot-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 12px;
+}
+
+.demon-fusion__results {
+    display: grid;
+    gap: 8px;
+    max-height: 220px;
+    overflow-y: auto;
+    padding-right: 4px;
+}
+
+.demon-fusion__result {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 12px;
+    padding: 8px 12px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--surface-2);
+    cursor: pointer;
+    transition: border-color var(--trans-fast), background var(--trans-fast), box-shadow var(--trans-fast);
+}
+
+.demon-fusion__result:hover,
+.demon-fusion__result:focus-visible {
+    outline: none;
+    border-color: var(--brand);
+    background: color-mix(in oklab, var(--brand) 12%, var(--surface-2));
+    box-shadow: var(--shadow-sm);
+}
+
+.demon-fusion__result-name { font-weight: 600; }
+
+.demon-fusion__selection {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 12px;
+    padding: 12px;
+    border-radius: var(--radius);
+    border: 1px solid color-mix(in oklab, var(--brand) 30%, var(--border));
+    background: color-mix(in oklab, var(--brand) 8%, var(--surface-1));
+}
+
+.demon-fusion__selection-actions { display: flex; gap: 8px; flex-wrap: wrap; }
+
+.demon-fusion__empty {
+    padding: 12px;
+    border: 1px dashed var(--border);
+    border-radius: var(--radius-sm);
+    text-align: center;
+    background: var(--surface-1);
+}
+
+.demon-fusion__summary-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 12px;
+}
+
+.demon-fusion__summary-grid { display: grid; gap: 8px; }
+
+.demon-fusion__summary-row {
+    display: flex;
+    justify-content: space-between;
+    gap: 12px;
+    font-size: 0.9rem;
+}
+
+.demon-fusion__result-card {
+    display: grid;
+    gap: 12px;
+    padding: 14px;
+    border: 1px solid color-mix(in oklab, var(--brand) 28%, var(--border));
+    border-radius: var(--radius);
+    background: color-mix(in oklab, var(--brand) 10%, var(--surface));
+}
+
+.demon-fusion__result-meta { display: grid; gap: 6px; }
+
+.demon-fusion__result-stats { display: flex; flex-wrap: wrap; gap: 8px; }
+
+.demon-fusion__result-resist { display: grid; gap: 4px; }
+
+.demon-fusion__result-skills { display: grid; gap: 4px; font-size: 0.85rem; }
+
+.demon-fusion__candidate-nav { display: flex; flex-wrap: wrap; gap: 8px; }
+
+.demon-fusion__actions { display: flex; flex-wrap: wrap; gap: 8px; }
+
+.demon-fusion__candidate-list { display: grid; gap: 8px; }
+
+.demon-fusion__candidate-scroll {
+    max-height: 240px;
+    overflow-y: auto;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    background: var(--surface-1);
+}
+
+.demon-fusion__candidate {
+    width: 100%;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 12px;
+    padding: 8px 12px;
+    background: transparent;
+    border: none;
+    border-bottom: 1px solid var(--border);
+    cursor: pointer;
+    text-align: left;
+    font-size: 0.9rem;
+}
+
+.demon-fusion__candidate:last-child { border-bottom: none; }
+
+.demon-fusion__candidate:hover,
+.demon-fusion__candidate:focus-visible {
+    outline: none;
+    background: color-mix(in oklab, var(--brand) 12%, transparent);
+}
+
+.demon-fusion__candidate.is-active {
+    background: color-mix(in oklab, var(--brand) 18%, transparent);
+    font-weight: 600;
+}
+
+@media (max-width: 720px) {
+    .demon-fusion__grid { grid-template-columns: 1fr; }
+}
 
 @media (min-width: 960px) {
     .demon-codex__layout { flex-direction: row; align-items: flex-start; }

--- a/client/src/utils/fusion.js
+++ b/client/src/utils/fusion.js
@@ -1,0 +1,62 @@
+import { ARCANA_DATA } from "../constants/gameData";
+
+const ARCANA_KEYS = ARCANA_DATA.map((entry) => entry.key);
+const ARCANA_LABEL_BY_KEY = new Map(ARCANA_DATA.map((entry) => [entry.key, entry.label]));
+const ARCANA_KEY_BY_LABEL = new Map(
+    ARCANA_DATA.map((entry) => [entry.label.toLowerCase(), entry.key]),
+);
+
+const FUSION_RULE_OVERRIDES = new Map();
+
+function buildPairKey(a, b) {
+    const list = [a, b].map((value) => value || "").sort();
+    return list.join("+");
+}
+
+export function normalizeArcanaKey(value) {
+    if (typeof value !== "string") return "";
+    const trimmed = value.trim();
+    if (!trimmed) return "";
+    const lower = trimmed.toLowerCase();
+    if (ARCANA_KEY_BY_LABEL.has(lower)) {
+        return ARCANA_KEY_BY_LABEL.get(lower) || "";
+    }
+    if (ARCANA_KEYS.includes(lower)) {
+        return lower;
+    }
+    return "";
+}
+
+export function getArcanaLabel(key) {
+    const normalized = normalizeArcanaKey(key);
+    return normalized ? ARCANA_LABEL_BY_KEY.get(normalized) || "" : "";
+}
+
+export function listArcanaOptions() {
+    return ARCANA_DATA.map((entry) => ({ key: entry.key, label: entry.label }));
+}
+
+export function suggestFusionArcana(arcanaA, arcanaB) {
+    const keyA = normalizeArcanaKey(arcanaA);
+    const keyB = normalizeArcanaKey(arcanaB);
+    if (!keyA || !keyB) return null;
+    const override = FUSION_RULE_OVERRIDES.get(buildPairKey(keyA, keyB));
+    if (override) {
+        return normalizeArcanaKey(override) || null;
+    }
+    if (keyA === keyB) return keyA;
+    const indexA = ARCANA_KEYS.indexOf(keyA);
+    const indexB = ARCANA_KEYS.indexOf(keyB);
+    if (indexA === -1 || indexB === -1) return null;
+    const averageIndex = Math.round((indexA + indexB) / 2);
+    return ARCANA_KEYS[averageIndex] || null;
+}
+
+export function describeFusionPair(arcanaA, arcanaB) {
+    const keyA = normalizeArcanaKey(arcanaA);
+    const keyB = normalizeArcanaKey(arcanaB);
+    if (!keyA || !keyB) return "";
+    const labelA = getArcanaLabel(keyA) || arcanaA;
+    const labelB = getArcanaLabel(keyB) || arcanaB;
+    return `${labelA} × ${labelB}`;
+}

--- a/server/services/demons.js
+++ b/server/services/demons.js
@@ -1,4 +1,76 @@
 import Demon from '../models/Demon.js';
+import { loadDemonEntries } from '../lib/demonImport.js';
+
+const DB_READY_STATE_CONNECTED = 1;
+let localDemonCachePromise = null;
+
+async function loadLocalDemonCache() {
+    if (!localDemonCachePromise) {
+        localDemonCachePromise = (async () => {
+            try {
+                const rawEntries = await loadDemonEntries();
+                const entries = rawEntries.map((entry) => {
+                    const searchParts = new Set();
+                    searchParts.add(entry.slug);
+                    searchParts.add(entry.name);
+                    searchParts.add(entry.arcana);
+                    searchParts.add(entry.alignment);
+                    searchParts.add(entry.description);
+                    if (Array.isArray(entry.tags)) {
+                        for (const tag of entry.tags) searchParts.add(tag);
+                    }
+                    if (Array.isArray(entry.searchTerms)) {
+                        for (const term of entry.searchTerms) searchParts.add(term);
+                    }
+                    if (Array.isArray(entry.skills)) {
+                        for (const skill of entry.skills) {
+                            if (!skill) continue;
+                            if (typeof skill === 'string') {
+                                searchParts.add(skill);
+                            } else if (skill.name) {
+                                searchParts.add(skill.name);
+                            }
+                        }
+                    }
+                    const parts = Array.from(searchParts)
+                        .map((value) => (typeof value === 'string' ? value.trim() : String(value ?? '')).toLowerCase())
+                        .filter(Boolean);
+                    const searchText = parts.join(' ');
+                    const comparison = parts.map((value) => normalizeComparisonTerm(value)).filter(Boolean);
+                    return {
+                        ...entry,
+                        _searchText: searchText,
+                        _comparisonTerms: comparison,
+                    };
+                });
+                const bySlug = new Map();
+                for (const entry of entries) {
+                    if (!entry?.slug) continue;
+                    bySlug.set(entry.slug, entry);
+                }
+                return { entries, bySlug };
+            } catch (err) {
+                console.warn('[demons] Failed to load local demon cache:', err);
+                return { entries: [], bySlug: new Map() };
+            }
+        })();
+    }
+    return localDemonCachePromise;
+}
+
+function sanitizeLocalDemon(entry) {
+    if (!entry) return null;
+    const { slug, ...rest } = entry;
+    return {
+        ...rest,
+        slug,
+        query: slug,
+    };
+}
+
+function isDatabaseReady() {
+    return Demon?.db?.readyState === DB_READY_STATE_CONNECTED;
+}
 
 function sanitizeDemonDoc(doc) {
     if (!doc) return null;
@@ -74,68 +146,99 @@ export async function searchDemons(term, { limit = 25 } = {}) {
     if (!query) return [];
 
     const regex = buildLooseRegex(query);
-    const filters = regex
-        ? {
-            $or: [
-                { slug: regex },
-                { name: regex },
-                { arcana: regex },
-                { alignment: regex },
-                { tags: regex },
-                { searchTerms: regex },
-                { description: regex },
-                { skills: regex },
-            ],
+    const normalizedLimit = Math.max(1, Math.min(100, limit));
+
+    if (isDatabaseReady()) {
+        const filters = regex
+            ? {
+                $or: [
+                    { slug: regex },
+                    { name: regex },
+                    { arcana: regex },
+                    { alignment: regex },
+                    { tags: regex },
+                    { searchTerms: regex },
+                    { description: regex },
+                    { skills: regex },
+                ],
+            }
+            : {};
+
+        try {
+            const docs = await Demon.find(filters)
+                .sort({ level: 1, name: 1 })
+                .limit(normalizedLimit)
+                .lean();
+            if (docs.length > 0) {
+                return docs.map((doc) => sanitizeDemonDoc(doc));
+            }
+        } catch (err) {
+            console.warn('[demons] Falling back to local demon search:', err);
         }
-        : {};
+    }
 
-    const docs = await Demon.find(filters)
-        .sort({ level: 1, name: 1 })
-        .limit(Math.max(1, Math.min(100, limit)))
-        .lean();
+    const { entries } = await loadLocalDemonCache();
+    if (!Array.isArray(entries) || entries.length === 0) return [];
 
-    return docs.map((doc) => sanitizeDemonDoc(doc));
+    const fallbackTerm = query.toLowerCase();
+    const matches = [];
+    for (const entry of entries) {
+        const searchText = entry?._searchText || '';
+        if (!searchText) continue;
+        const hit = regex ? regex.test(searchText) : searchText.includes(fallbackTerm);
+        if (hit) {
+            matches.push(entry);
+        }
+    }
+
+    matches.sort((a, b) => {
+        const levelA = Number(a.level) || 0;
+        const levelB = Number(b.level) || 0;
+        if (levelA !== levelB) return levelA - levelB;
+        const nameA = String(a.name || '');
+        const nameB = String(b.name || '');
+        return nameA.localeCompare(nameB, undefined, { numeric: true, sensitivity: 'base' });
+    });
+
+    return matches
+        .slice(0, normalizedLimit)
+        .map((entry) => sanitizeLocalDemon(entry))
+        .filter(Boolean);
 }
 
 export async function findDemonBySlug(slug) {
     if (typeof slug !== 'string' || !slug.trim()) return null;
     const normalized = slug.trim().toLowerCase();
-    const doc = await Demon.findOne({ slug: normalized }).lean();
-    return sanitizeDemonDoc(doc);
+    if (isDatabaseReady()) {
+        try {
+            const doc = await Demon.findOne({ slug: normalized }).lean();
+            if (doc) return sanitizeDemonDoc(doc);
+        } catch (err) {
+            console.warn('[demons] Failed to query demon by slug from Mongo, trying local cache:', err);
+        }
+    }
+
+    const { bySlug } = await loadLocalDemonCache();
+    return sanitizeLocalDemon(bySlug.get(normalized));
 }
 
 export async function findClosestDemon(term, { threshold = 0.45 } = {}) {
     const normalized = normalizeComparisonTerm(term);
     if (!normalized) return null;
-    const docs = await Demon.find({}, { slug: 1, name: 1, searchTerms: 1 })
-        .limit(1500)
-        .lean();
-    let best = null;
-    for (const doc of docs) {
-        const options = new Set([
-            doc.slug,
-            doc.name,
-            ...(Array.isArray(doc.searchTerms) ? doc.searchTerms : []),
-        ]);
-        for (const option of options) {
-            const normalizedOption = normalizeComparisonTerm(option);
-            if (!normalizedOption) continue;
-            const distance = levenshtein(normalized, normalizedOption);
-            const maxLen = Math.max(normalized.length, normalizedOption.length, 1);
-            const ratio = distance / maxLen;
-            if (ratio <= threshold) {
-                if (!best || ratio < best.ratio) {
-                    best = {
-                        ratio,
-                        distance,
-                        slug: doc.slug,
-                        name: doc.name,
-                    };
-                }
-            }
+    if (isDatabaseReady()) {
+        try {
+            const docs = await Demon.find({}, { slug: 1, name: 1, searchTerms: 1 })
+                .limit(1500)
+                .lean();
+            const best = computeClosestMatch(normalized, docs, threshold);
+            if (best) return best;
+        } catch (err) {
+            console.warn('[demons] findClosest fallback to local cache:', err);
         }
     }
-    return best;
+
+    const { entries } = await loadLocalDemonCache();
+    return computeClosestMatch(normalized, entries, threshold);
 }
 
 export function summarizeDemon(demon) {
@@ -171,5 +274,80 @@ export function buildDemonDetailString(demon) {
     if (Number.isFinite(demon.level)) parts.push(`Level ${demon.level}`);
     if (parts.length === 0) return 'Uncatalogued demon';
     return parts.join(' · ');
+}
+
+function computeClosestMatch(normalizedTerm, docs, threshold) {
+    if (!Array.isArray(docs) || docs.length === 0) return null;
+    let best = null;
+    for (const doc of docs) {
+        if (!doc) continue;
+        const options = new Set([
+            doc.slug,
+            doc.name,
+            ...(Array.isArray(doc.searchTerms) ? doc.searchTerms : []),
+            ...(Array.isArray(doc._comparisonTerms) ? doc._comparisonTerms : []),
+        ]);
+        for (const option of options) {
+            const normalizedOption = normalizeComparisonTerm(option);
+            if (!normalizedOption) continue;
+            const distance = levenshtein(normalizedTerm, normalizedOption);
+            const maxLen = Math.max(normalizedTerm.length, normalizedOption.length, 1);
+            const ratio = distance / maxLen;
+            if (ratio <= threshold) {
+                if (!best || ratio < best.ratio) {
+                    best = {
+                        ratio,
+                        distance,
+                        slug: doc.slug,
+                        name: doc.name,
+                    };
+                }
+            }
+        }
+    }
+    return best;
+}
+
+export async function listDemons({ arcana, limit = 200 } = {}) {
+    const normalizedLimit = Math.max(1, Math.min(200, Number(limit) || 200));
+    const arcanaValue = typeof arcana === 'string' ? arcana.trim() : '';
+    const arcanaRegex = arcanaValue ? new RegExp(`^${escapeRegExp(arcanaValue)}$`, 'i') : null;
+
+    if (isDatabaseReady()) {
+        const filters = arcanaRegex ? { arcana: arcanaRegex } : {};
+        try {
+            const docs = await Demon.find(filters)
+                .sort({ level: 1, name: 1 })
+                .limit(normalizedLimit)
+                .lean();
+            if (docs.length > 0) {
+                return docs.map((doc) => sanitizeDemonDoc(doc));
+            }
+        } catch (err) {
+            console.warn('[demons] listDemons fell back to local cache:', err);
+        }
+    }
+
+    const { entries } = await loadLocalDemonCache();
+    if (!Array.isArray(entries) || entries.length === 0) return [];
+
+    let filtered = entries;
+    if (arcanaRegex) {
+        filtered = filtered.filter((entry) => arcanaRegex.test(String(entry.arcana || '')));
+    }
+
+    const sorted = [...filtered].sort((a, b) => {
+        const levelA = Number(a.level) || 0;
+        const levelB = Number(b.level) || 0;
+        if (levelA !== levelB) return levelA - levelB;
+        const nameA = String(a.name || '');
+        const nameB = String(b.name || '');
+        return nameA.localeCompare(nameB, undefined, { numeric: true, sensitivity: 'base' });
+    });
+
+    return sorted
+        .slice(0, normalizedLimit)
+        .map((entry) => sanitizeLocalDemon(entry))
+        .filter(Boolean);
 }
 


### PR DESCRIPTION
## Summary
- add a cached fallback for persona search and expose a listing endpoint to support tools
- build a DM-only demon fusion planner that pulls compendium data, suggests results, and pushes fused demons to the pool
- refresh demon codex styling to accommodate the lookup and fusion workspace

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d6a86d09f88331b60528ba72ca133e