### PR TITLE
Add shared session music playback and sidebar controls

### DIFF
--- a/client/src/style.css
+++ b/client/src/style.css
@@ -1808,6 +1808,55 @@ p  { margin: 0 0 .75rem; color: var(--text); }
     line-height: 1.4;
 }
 
+.sidebar__audio-panel {
+    margin: 24px 16px 0;
+    padding: 12px;
+    border-radius: var(--radius);
+    border: 1px solid var(--border);
+    background: var(--surface-2);
+    display: grid;
+    gap: 10px;
+}
+
+.sidebar__audio-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 8px;
+}
+
+.sidebar__audio-title {
+    font-weight: 600;
+    font-size: 0.9rem;
+}
+
+.sidebar__audio-controls {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    gap: 8px;
+    align-items: center;
+}
+
+.sidebar__audio-controls input[type="range"] {
+    width: 100%;
+}
+
+.sidebar__audio-volume {
+    font-size: 0.8rem;
+    color: var(--muted);
+    min-width: 3ch;
+    text-align: right;
+}
+
+.sidebar__audio-track {
+    font-size: 0.85rem;
+    color: var(--muted);
+}
+
+.sidebar__audio-track strong {
+    color: var(--text);
+}
+
 .sidebar__footer {
     margin-top: auto;
     display: grid;
@@ -2697,6 +2746,14 @@ p  { margin: 0 0 .75rem; color: var(--text); }
     display: grid;
     gap: 12px;
     padding: 12px 16px 16px;
+}
+
+.shared-media__body--compact {
+    gap: 8px;
+}
+
+.shared-media__track {
+    font-size: 0.95rem;
 }
 
 .shared-media__player {

--- a/client/src/utils/music.js
+++ b/client/src/utils/music.js
@@ -1,0 +1,22 @@
+import { MAIN_MENU_TRACK_ID, MUSIC_TRACKS } from "@shared/music/index.js";
+
+const TRACKS_WITH_SOURCES = MUSIC_TRACKS.map((track) => ({
+    ...track,
+    src: new URL(`../../../shared/music/${track.filename}`, import.meta.url).href,
+}));
+
+const TRACK_MAP = new Map(TRACKS_WITH_SOURCES.map((track) => [track.id, track]));
+
+export function getAvailableTracks() {
+    return TRACKS_WITH_SOURCES;
+}
+
+export function getTrackById(trackId) {
+    if (!trackId) return null;
+    return TRACK_MAP.get(trackId) || null;
+}
+
+export function getMainMenuTrack() {
+    if (!MAIN_MENU_TRACK_ID) return null;
+    return getTrackById(MAIN_MENU_TRACK_ID);
+}

--- a/shared/music/index.js
+++ b/shared/music/index.js
@@ -1,0 +1,24 @@
+export const MUSIC_TRACKS = [
+    {
+        id: "recovery-spring",
+        title: "Recovery Spring",
+        subtitle: "Shin Megami Tensei III: Nocturne",
+        filename: "Recovery Spring - SMT III_ Nocturne.mp3",
+        loop: true,
+        default: true,
+    },
+];
+
+export const MUSIC_TRACK_MAP = new Map(MUSIC_TRACKS.map((track) => [track.id, track]));
+
+export function getMusicTrack(trackId) {
+    if (!trackId) return null;
+    return MUSIC_TRACK_MAP.get(trackId) || null;
+}
+
+export function getDefaultMusicTrack() {
+    const firstDefault = MUSIC_TRACKS.find((track) => track.default);
+    return firstDefault || MUSIC_TRACKS[0] || null;
+}
+
+export const MAIN_MENU_TRACK_ID = getDefaultMusicTrack()?.id || null;


### PR DESCRIPTION
## Summary
- add a global music provider that plays menu ambience, synchronizes in-session tracks, and refreshes the shared music display
- let DMs choose campaign tracks from the shared music library and broadcast them to players via realtime updates
- surface volume and mute controls in the sidebar, update styling, and expand server support for music state

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d6aa53f2dc8331a876cef3bc50a26d