### PR TITLE
Gate moon phase randomization on critical rolls

### DIFF
--- a/client/src/utils/fusion.js
+++ b/client/src/utils/fusion.js
@@ -217,7 +217,11 @@ export function createFusionPlan({ demonA, demonB, fuseSeed, moonPhase }) {
     let candidates = [];
     const chartArcana = resolveChartArcana(arcanaA, arcanaB);
 
-    if (normalizedPhase === MOON_PHASES.FULL || normalizedPhase === MOON_PHASES.NEW) {
+    const shouldRandomize =
+        (normalizedPhase === MOON_PHASES.FULL && roll?.isCriticalHigh) ||
+        (normalizedPhase === MOON_PHASES.NEW && roll?.isCriticalLow);
+
+    if (shouldRandomize) {
         arcanaSource = "random";
         candidates = buildRandomArcanaOrder(baseSeed);
     } else if (chartArcana) {


### PR DESCRIPTION
## Summary
- restrict full and new moon fusion randomization to cases where the D20 roll is a critical result
- fall back to the standard arcana selection logic when the roll is not critical

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d7e70391fc83318701e627b363756a