### PR TITLE
Refine world skills management

### DIFF
--- a/client/src/components/WorldSkillsTab.jsx
+++ b/client/src/components/WorldSkillsTab.jsx
@@ -1333,116 +1333,105 @@ function WorldSkillsTab({ game, me, onUpdate }) {
                                     : "Everything is hidden. Use “Show hidden” to bring skills back."}
                             </div>
                         ) : (
-                            <div className="sheet-table-wrapper">
-                                <table className="sheet-table skill-table">
-                                    <thead>
-                                        <tr>
-                                            <th>Skill</th>
-                                            <th>Ability</th>
-                                            <th>Ability mod</th>
-                                            <th>Ranks</th>
-                                            <th>Misc</th>
-                                            <th>Total</th>
-                                            {isDM && <th aria-label="Actions" />}
-                                        </tr>
-                                    </thead>
-                                    <tbody>
-                                        {plannerSkillRows.map((row) => {
-                                            const isFavorite = favoriteSkillIds.has(row.id);
-                                            return (
-                                                <tr key={row.key}>
-                                                    <th scope="row">
-                                                        <div className="skill-table__header">
-                                                            <span className="skill-name">{row.label}</span>
-                                                            <div className="skill-table__header-actions">
-                                                                <button
-                                                                    type="button"
-                                                                    className={`skill-card__icon-btn skill-card__icon-btn--star${
-                                                                        isFavorite ? " is-active" : ""
-                                                                    }`}
-                                                                    onClick={() => toggleFavoriteSkill(row.id)}
-                                                                    aria-pressed={isFavorite}
-                                                                    aria-label={
-                                                                        isFavorite
-                                                                            ? `Unstar ${row.label}`
-                                                                            : `Star ${row.label}`
-                                                                    }
-                                                                    title={
-                                                                        isFavorite
-                                                                            ? "Unstar to remove from the pinned list"
-                                                                            : "Star to pin this skill to the top"
-                                                                    }
-                                                                >
-                                                                    {isFavorite ? "★" : "☆"}
-                                                                </button>
-                                                                <button
-                                                                    type="button"
-                                                                    className="skill-card__icon-btn"
-                                                                    onClick={() => {
-                                                                        hideSkillFromView(row.id);
-                                                                        setShowHiddenSkills(true);
-                                                                    }}
-                                                                    aria-label={`Hide ${row.label}`}
-                                                                    title="Hide this skill from the table"
-                                                                >
-                                                                    Hide
-                                                                </button>
-                                                            </div>
-                                                        </div>
-                                                    </th>
-                                                <td>{row.ability}</td>
-                                                <td>
+                            <div className="world-skill-grid world-skill-grid--planner">
+                                {plannerSkillRows.map((row) => {
+                                    const abilityInfo = abilityDetails[row.ability] || null;
+                                    const isFavorite = favoriteSkillIds.has(row.id);
+                                    const rowKey = row.id || row.key || row.label;
+                                    return (
+                                        <div
+                                            key={rowKey}
+                                            className={`world-skill-card world-skill-rank-card${
+                                                isFavorite ? " is-favorite" : ""
+                                            }`}
+                                        >
+                                            <div className="world-skill-card__header">
+                                                <span className="world-skill-card__badge">{row.ability}</span>
+                                                <div className="skill-card__toolbar">
+                                                    <button
+                                                        type="button"
+                                                        className={`skill-card__icon-btn skill-card__icon-btn--star${
+                                                            isFavorite ? " is-active" : ""
+                                                        }`}
+                                                        onClick={() => toggleFavoriteSkill(row.id)}
+                                                        aria-pressed={isFavorite}
+                                                        aria-label={
+                                                            isFavorite
+                                                                ? `Unstar ${row.label}`
+                                                                : `Star ${row.label}`
+                                                        }
+                                                        title={
+                                                            isFavorite
+                                                                ? "Unstar to remove from the pinned list"
+                                                                : "Star to pin this skill to the top"
+                                                        }
+                                                    >
+                                                        {isFavorite ? "★" : "☆"}
+                                                    </button>
+                                                    <button
+                                                        type="button"
+                                                        className="skill-card__icon-btn"
+                                                        onClick={() => {
+                                                            hideSkillFromView(row.id);
+                                                            setShowHiddenSkills(true);
+                                                        }}
+                                                        aria-label={`Hide ${row.label}`}
+                                                        title="Hide this skill from the planner"
+                                                    >
+                                                        Hide
+                                                    </button>
+                                                </div>
+                                            </div>
+                                            <div className="world-skill-card__body world-skill-rank-card__body">
+                                                <div className="world-skill-rank-card__heading">
+                                                    <h4>{row.label}</h4>
+                                                    {abilityInfo?.label && (
+                                                        <span className="text-muted text-small">
+                                                            {abilityInfo.label}
+                                                        </span>
+                                                    )}
+                                                </div>
+                                                <div className="world-skill-rank-card__summary">
                                                     <span className="pill light">
-                                                        {formatModifier(row.abilityMod)}
+                                                        Ability mod {formatModifier(row.abilityMod)}
                                                     </span>
-                                                </td>
-                                                <td>
+                                                    <span className="world-skill-rank-card__total">
+                                                        Total
+                                                        <span className="skill-total">{formatModifier(row.total)}</span>
+                                                    </span>
+                                                </div>
+                                                <div className="world-skill-rank-card__fields">
                                                     <MathField
                                                         label="Ranks"
                                                         value={row.ranks}
-                                                        onCommit={(val) =>
-                                                            updateSkill(row.key, "ranks", val)
-                                                        }
+                                                        onCommit={(val) => updateSkill(row.key, "ranks", val)}
                                                         className="math-inline"
                                                         disabled={disableInputs}
                                                     />
-                                                </td>
-                                                <td>
                                                     <MathField
                                                         label="Misc"
                                                         value={row.misc}
-                                                        onCommit={(val) =>
-                                                            updateSkill(row.key, "misc", val)
-                                                        }
+                                                        onCommit={(val) => updateSkill(row.key, "misc", val)}
                                                         className="math-inline"
                                                         disabled={disableInputs}
                                                     />
-                                                </td>
-                                                <td>
-                                                    <span className="skill-total">
-                                                        {formatModifier(row.total)}
-                                                    </span>
-                                                </td>
+                                                </div>
                                                 {isDM && (
-                                                    <td>
-                                                        <button
-                                                            type="button"
-                                                            className="btn btn-small danger"
-                                                            onClick={() => handleTakeAwaySkill(row.key, row.label)}
-                                                            disabled={
-                                                                disableInputs ||
-                                                                (row.ranks === 0 && row.misc === 0)
-                                                            }
-                                                        >
-                                                            Take away
-                                                        </button>
-                                                    </td>
+                                                    <button
+                                                        type="button"
+                                                        className="btn btn-small danger world-skill-rank-card__take-away"
+                                                        onClick={() => handleTakeAwaySkill(row.key, row.label)}
+                                                        disabled={
+                                                            disableInputs || (row.ranks === 0 && row.misc === 0)
+                                                        }
+                                                    >
+                                                        Take away
+                                                    </button>
                                                 )}
-                                            </tr>
-                                            );
-                                        })}
-                                    </tbody>
-                                </table>
+                                            </div>
+                                        </div>
+                                    );
+                                })}
                             </div>
                         )}
 

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -3075,6 +3075,7 @@ label {
 .world-skill-manager__sort select { min-width: 170px; }
 .world-skill-manager__status { color: var(--brand-600); font-weight: 600; letter-spacing: 0.04em; }
 .world-skill-grid { display: grid; gap: 14px; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); }
+.world-skill-grid--planner { grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); }
 .world-skill-card { position: relative; border: 1px solid var(--border); border-radius: var(--radius); padding: 16px; background: var(--surface-2); display: grid; gap: 12px; min-height: 180px; transition: border-color var(--trans-fast), box-shadow var(--trans-fast), transform var(--trans-fast); }
 .world-skill-card:hover { border-color: color-mix(in oklab, var(--brand) 40%, var(--border) 60%); box-shadow: 0 8px 22px rgba(15,17,21,0.16); transform: translateY(-2px); }
 .world-skill-card.is-editing { border-color: var(--brand); box-shadow: 0 12px 28px rgba(15,17,21,0.18); }
@@ -3084,7 +3085,13 @@ label {
 .world-skill-card__delete:hover:not(:disabled) { color: var(--danger); transform: scale(1.1); }
 .world-skill-card__delete:disabled { opacity: 0.55; cursor: progress; }
 .world-skill-card__body { display: grid; gap: 8px; align-content: start; }
+.world-skill-rank-card__body { gap: 14px; }
 .world-skill-card__body h4 { margin: 0; font-size: 1.05rem; color: var(--text); }
+.world-skill-rank-card__heading { display: flex; flex-direction: column; gap: 2px; }
+.world-skill-rank-card__summary { display: flex; justify-content: space-between; align-items: center; gap: 8px; flex-wrap: wrap; }
+.world-skill-rank-card__total { display: inline-flex; align-items: baseline; gap: 6px; font-weight: 600; }
+.world-skill-rank-card__fields { display: grid; gap: 10px; grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); align-items: end; }
+.world-skill-rank-card__take-away { justify-self: flex-start; }
 .world-skill-card__actions { display: flex; gap: 8px; flex-wrap: wrap; }
 .world-skill-card__form { display: grid; gap: 12px; align-content: start; }
 .world-skill-card--add { border-style: dashed; border-color: color-mix(in oklab, var(--border) 70%, var(--brand) 30%); align-content: center; justify-items: center; text-align: center; }


### PR DESCRIPTION
## Summary
- remove the world skills editor from the My Character sheet so ranks are managed only from the World Skills tab
- switch the planner to a card-based grid that retains favorite, search, sort, and hide controls while editing ranks and misc bonuses
- add supporting styles for the new planner layout

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d7faf339308331bd99d25c28f2a39f