### PR TITLE
docs: add comprehensive jsdoc across client utilities

### DIFF
--- a/client/src/utils/character.js
+++ b/client/src/utils/character.js
@@ -5,11 +5,37 @@ import {
     normalizeCustomSkills,
 } from "../constants/gameData";
 
+/**
+ * @typedef {{ key: string, label: string }} WorldSkill
+ * @typedef {{ ranks?: number, misc?: number, label?: string, ability?: string }} RawSkillEntry
+ * @typedef {{ ranks: number, misc: number }} NormalizedSkill
+ * @typedef {{
+ *   name: string,
+ *   profile: Record<string, any>,
+ *   stats: Record<string, any>,
+ *   resources: { useTP: boolean, [key: string]: any },
+ *   skills: Record<string, NormalizedSkill>,
+ *   customSkills: Array<Record<string, any>>,
+ * }} NormalizedCharacter
+ */
+
+/**
+ * Clone any JSON-serializable value, preferring the native structured clone when available.
+ * @template T
+ * @param {T} value - Value to clone.
+ * @returns {T} A deep copy of the provided value.
+ */
 export function deepClone(value) {
     if (typeof structuredClone === "function") return structuredClone(value);
     return JSON.parse(JSON.stringify(value));
 }
 
+/**
+ * Normalize a skill record to include only ranks/misc values while ensuring defaults for world skills.
+ * @param {Record<string, RawSkillEntry>} raw - Incoming skills map.
+ * @param {WorldSkill[]} worldSkills - Reference list of world skills.
+ * @returns {Record<string, NormalizedSkill>} Sanitized skills keyed by skill id.
+ */
 export function normalizeSkills(raw, worldSkills = DEFAULT_WORLD_SKILLS) {
     const out = {};
     if (raw && typeof raw === "object" && !Array.isArray(raw)) {
@@ -27,6 +53,13 @@ export function normalizeSkills(raw, worldSkills = DEFAULT_WORLD_SKILLS) {
     return out;
 }
 
+/**
+ * Convert loosely-typed character payloads into the canonical structure expected by the app.
+ * Ensures nested objects exist, converts truthy values, and normalizes skill/custom skill collections.
+ * @param {any} raw - Arbitrary character data from the API or storage.
+ * @param {WorldSkill[]} worldSkills - World skill metadata used for defaults.
+ * @returns {NormalizedCharacter} Normalized character object.
+ */
 export function normalizeCharacter(raw, worldSkills = DEFAULT_WORLD_SKILLS) {
     if (!raw || typeof raw !== "object") {
         return {

--- a/client/src/utils/constants.js
+++ b/client/src/utils/constants.js
@@ -1,2 +1,13 @@
+/**
+ * Shared immutable empty array reference.
+ * Useful for memoized selectors/hooks to avoid allocating new arrays.
+ * @type {readonly any[]}
+ */
 export const EMPTY_ARRAY = Object.freeze([]);
+
+/**
+ * Shared immutable empty object reference.
+ * Helps prevent re-renders when consumers expect referential stability.
+ * @type {Readonly<Record<string, never>>}
+ */
 export const EMPTY_OBJECT = Object.freeze({});

--- a/client/src/utils/items.js
+++ b/client/src/utils/items.js
@@ -1,11 +1,25 @@
+/**
+ * Keywords used to detect if an item belongs to a gear category.
+ * @type {readonly string[]}
+ */
 export const GEAR_TYPE_KEYWORDS = ["weapon", "armor", "accessory"];
 const GEAR_TYPE_PATTERNS = GEAR_TYPE_KEYWORDS.map((keyword) => new RegExp(`\\b${keyword}\\b`, "i"));
 
+/**
+ * Determine whether a type string references a gear category.
+ * @param {string} type
+ * @returns {boolean}
+ */
 export function isGearCategory(type) {
     if (typeof type !== "string") return false;
     return GEAR_TYPE_PATTERNS.some((pattern) => pattern.test(type));
 }
 
+/**
+ * Convert a healing payload into a compact human-readable description.
+ * @param {{ revive?: "full"|"partial", hpPercent?: number, hp?: number, mpPercent?: number, mp?: number }} healing
+ * @returns {string}
+ */
 export function formatHealingEffect(healing) {
     if (!healing || typeof healing !== "object") return "";
     const parts = [];

--- a/client/src/utils/music.js
+++ b/client/src/utils/music.js
@@ -1,5 +1,13 @@
 import { MAIN_MENU_TRACK_ID, MUSIC_TRACKS } from "@shared/music/index.js";
 
+/**
+ * @typedef {{ id: string, title: string, subtitle?: string, filename: string, loop?: boolean, default?: boolean }} MusicTrack
+ */
+
+/**
+ * Pre-resolved list of music tracks bundled with absolute source URLs.
+ * @type {Array<MusicTrack & { src: string }>}
+ */
 const TRACKS_WITH_SOURCES = MUSIC_TRACKS.map((track) => ({
     ...track,
     src: new URL(`../../../shared/music/${track.filename}`, import.meta.url).href,
@@ -7,15 +15,28 @@ const TRACKS_WITH_SOURCES = MUSIC_TRACKS.map((track) => ({
 
 const TRACK_MAP = new Map(TRACKS_WITH_SOURCES.map((track) => [track.id, track]));
 
+/**
+ * Return the catalog of music tracks with resolved source URLs.
+ * @returns {Array<MusicTrack & { src: string }>}
+ */
 export function getAvailableTracks() {
     return TRACKS_WITH_SOURCES;
 }
 
+/**
+ * Lookup a track by id, returning `null` if not found.
+ * @param {string} trackId
+ * @returns {MusicTrack & { src: string } | null}
+ */
 export function getTrackById(trackId) {
     if (!trackId) return null;
     return TRACK_MAP.get(trackId) || null;
 }
 
+/**
+ * Resolve the configured main menu track when available.
+ * @returns {MusicTrack & { src: string } | null}
+ */
 export function getMainMenuTrack() {
     if (!MAIN_MENU_TRACK_ID) return null;
     return getTrackById(MAIN_MENU_TRACK_ID);

--- a/client/src/utils/object.js
+++ b/client/src/utils/object.js
@@ -1,3 +1,10 @@
+/**
+ * Safely read a nested property from an object using dot notation.
+ * @template T
+ * @param {T} obj - The object to traverse.
+ * @param {string} path - Dot-separated property path (e.g. "profile.name").
+ * @returns {any} The resolved value or `undefined` when the path is missing.
+ */
 export function get(obj, path) {
     if (!obj || typeof obj !== "object" || typeof path !== "string") return undefined;
     const parts = path.split(".");

--- a/client/src/utils/skillViewPrefs.js
+++ b/client/src/utils/skillViewPrefs.js
@@ -1,9 +1,22 @@
+/**
+ * Canonical empty skill view preference payload.
+ * @type {{ favorites: readonly string[], hidden: readonly string[] }}
+ */
 export const EMPTY_SKILL_VIEW_PREFS = Object.freeze({ favorites: [], hidden: [] });
 
+/**
+ * Create a mutable clone of the default skill view preferences.
+ * @returns {{ favorites: string[], hidden: string[] }}
+ */
 export function createEmptySkillViewPrefs() {
     return { favorites: [], hidden: [] };
 }
 
+/**
+ * Normalize persisted skill view preferences into a deduplicated structure.
+ * @param {any} raw
+ * @returns {{ favorites: string[], hidden: string[] }}
+ */
 export function sanitizeSkillViewPrefs(raw) {
     if (!raw || typeof raw !== "object") {
         return createEmptySkillViewPrefs();


### PR DESCRIPTION
## Summary
- add type definitions and function JSDoc across client utility modules
- document fusion planning helpers with structured typedefs and richer context
- annotate the realtime connection hook, including helper callbacks and return contract

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d804e16e8083318c50cd3cd68f563a