### PR TITLE
Add editable fusion chart overrides for DM

### DIFF
--- a/client/src/api.js
+++ b/client/src/api.js
@@ -593,6 +593,8 @@ export const Games = {
     addDemon: (id, body) => api(`/api/games/${encodeURIComponent(id)}/demons`, { method: 'POST', body }),
     updateDemon: (id, demonId, body) => api(`/api/games/${encodeURIComponent(id)}/demons/${encodeURIComponent(demonId)}`, { method: 'PUT', body }),
     delDemon: (id, demonId) => api(`/api/games/${encodeURIComponent(id)}/demons/${encodeURIComponent(demonId)}`, { method: 'DELETE' }),
+    updateFusionChart: (id, payload) =>
+        api(`/api/games/${encodeURIComponent(id)}/fusion-chart`, { method: 'PUT', body: payload }),
 
     updateMapSettings: (id, settings) =>
         api(`/api/games/${encodeURIComponent(id)}/map/settings`, {

--- a/client/src/constants/fusionChart.js
+++ b/client/src/constants/fusionChart.js
@@ -1,62 +1,11 @@
-export const FUSION_ARCANA_METADATA = [
-    { key: "fool", label: "Fool" },
-    { key: "magician", label: "Magician" },
-    { key: "priestess", label: "Priestess" },
-    { key: "empress", label: "Empress" },
-    { key: "emperor", label: "Emperor" },
-    { key: "hierophant", label: "Hierophant" },
-    { key: "lovers", label: "Lovers" },
-    { key: "chariot", label: "Chariot" },
-    { key: "justice", label: "Justice" },
-    { key: "hermit", label: "Hermit" },
-    { key: "fortune", label: "Fortune" },
-    { key: "strength", label: "Strength" },
-    { key: "hanged", label: "Hanged", aliases: ["hanged man"] },
-    { key: "death", label: "Death" },
-    { key: "temperance", label: "Temperance" },
-    { key: "devil", label: "Devil" },
-    { key: "tower", label: "Tower" },
-    { key: "star", label: "Star" },
-    { key: "moon", label: "Moon" },
-    { key: "sun", label: "Sun" },
-    { key: "judgement", label: "Judgement", aliases: ["judgment"] },
-    { key: "aeon", label: "Aeon" },
-    { key: "jester", label: "Jester" },
-];
+import {
+    FUSION_ARCANA_METADATA,
+    FUSE_ARCANA_LABEL_BY_KEY,
+    FUSE_ARCANA_KEY_BY_LABEL,
+    FUSE_ARCANA_ORDER,
+    buildDefaultFusionChart,
+} from "../../../shared/fusionArcana.js";
 
-export const FUSE_ARCANA_ORDER = FUSION_ARCANA_METADATA.map((entry) => entry.key);
+export { FUSION_ARCANA_METADATA, FUSE_ARCANA_LABEL_BY_KEY, FUSE_ARCANA_KEY_BY_LABEL, FUSE_ARCANA_ORDER };
 
-export const FUSE_ARCANA_LABEL_BY_KEY = new Map(
-    FUSION_ARCANA_METADATA.map((entry) => [entry.key, entry.label]),
-);
-
-const FUSE_ARCANA_KEY_BY_LABEL_ENTRIES = [];
-for (const entry of FUSION_ARCANA_METADATA) {
-    const base = entry.label.toLowerCase();
-    FUSE_ARCANA_KEY_BY_LABEL_ENTRIES.push([base, entry.key]);
-    FUSE_ARCANA_KEY_BY_LABEL_ENTRIES.push([entry.key.toLowerCase(), entry.key]);
-    if (Array.isArray(entry.aliases)) {
-        for (const alias of entry.aliases) {
-            if (!alias) continue;
-            FUSE_ARCANA_KEY_BY_LABEL_ENTRIES.push([alias.toLowerCase(), entry.key]);
-        }
-    }
-}
-
-export const FUSE_ARCANA_KEY_BY_LABEL = new Map(FUSE_ARCANA_KEY_BY_LABEL_ENTRIES);
-
-function buildFuseChart() {
-    const chart = {};
-    for (let row = 0; row < FUSE_ARCANA_ORDER.length; row += 1) {
-        const rowKey = FUSE_ARCANA_ORDER[row];
-        chart[rowKey] = {};
-        for (let col = 0; col < FUSE_ARCANA_ORDER.length; col += 1) {
-            const colKey = FUSE_ARCANA_ORDER[col];
-            const avgIndex = Math.round((row + col) / 2);
-            chart[rowKey][colKey] = FUSE_ARCANA_ORDER[avgIndex];
-        }
-    }
-    return chart;
-}
-
-export const FUSE_CHART = buildFuseChart();
+export const FUSE_CHART = buildDefaultFusionChart();

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -3260,7 +3260,8 @@ label {
 }
 
 .demon-fusion__slot,
-.demon-fusion__summary {
+.demon-fusion__summary,
+.demon-fusion__chart {
     display: grid;
     gap: 12px;
     padding: 16px;
@@ -3275,6 +3276,78 @@ label {
     justify-content: space-between;
     align-items: flex-start;
     gap: 12px;
+}
+
+.demon-fusion__chart-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 12px;
+}
+
+.demon-fusion__chart-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+
+.demon-fusion__chart-grid {
+    overflow: auto;
+    border-radius: var(--radius);
+    border: 1px solid var(--border);
+    background: var(--surface-2);
+    max-height: 480px;
+}
+
+.demon-fusion__chart-table {
+    border-collapse: collapse;
+    width: 100%;
+    min-width: 720px;
+    font-size: 0.85rem;
+}
+
+.demon-fusion__chart-table th,
+.demon-fusion__chart-table td {
+    border: 1px solid var(--border);
+    padding: 6px;
+    text-align: center;
+    background: var(--surface);
+}
+
+.demon-fusion__chart-table thead th {
+    position: sticky;
+    top: 0;
+    background: var(--surface-2);
+    z-index: 1;
+}
+
+.demon-fusion__chart-table thead th.demon-fusion__chart-corner {
+    left: 0;
+    z-index: 2;
+}
+
+.demon-fusion__chart-table tbody th {
+    background: var(--surface-2);
+    position: sticky;
+    left: 0;
+    text-align: left;
+    z-index: 1;
+    font-weight: 600;
+}
+
+.demon-fusion__chart-corner {
+    text-align: left;
+    min-width: 140px;
+}
+
+.demon-fusion__chart-select {
+    width: 100%;
+    min-width: 110px;
+    font-size: 0.82rem;
+}
+
+.demon-fusion__chart-cell.has-override {
+    background: color-mix(in oklab, var(--brand) 12%, transparent);
 }
 
 .demon-fusion__results {

--- a/shared/fusionArcana.js
+++ b/shared/fusionArcana.js
@@ -1,0 +1,60 @@
+export const FUSION_ARCANA_METADATA = [
+    { key: "fool", label: "Fool" },
+    { key: "magician", label: "Magician" },
+    { key: "priestess", label: "Priestess" },
+    { key: "empress", label: "Empress" },
+    { key: "emperor", label: "Emperor" },
+    { key: "hierophant", label: "Hierophant" },
+    { key: "lovers", label: "Lovers" },
+    { key: "chariot", label: "Chariot" },
+    { key: "justice", label: "Justice" },
+    { key: "hermit", label: "Hermit" },
+    { key: "fortune", label: "Fortune" },
+    { key: "strength", label: "Strength" },
+    { key: "hanged", label: "Hanged", aliases: ["hanged man"] },
+    { key: "death", label: "Death" },
+    { key: "temperance", label: "Temperance" },
+    { key: "devil", label: "Devil" },
+    { key: "tower", label: "Tower" },
+    { key: "star", label: "Star" },
+    { key: "moon", label: "Moon" },
+    { key: "sun", label: "Sun" },
+    { key: "judgement", label: "Judgement", aliases: ["judgment"] },
+    { key: "aeon", label: "Aeon" },
+    { key: "jester", label: "Jester" },
+];
+
+export const FUSE_ARCANA_ORDER = FUSION_ARCANA_METADATA.map((entry) => entry.key);
+
+export const FUSE_ARCANA_LABEL_BY_KEY = new Map(
+    FUSION_ARCANA_METADATA.map((entry) => [entry.key, entry.label]),
+);
+
+const FUSE_ARCANA_KEY_BY_LABEL_ENTRIES = [];
+for (const entry of FUSION_ARCANA_METADATA) {
+    const base = entry.label.toLowerCase();
+    FUSE_ARCANA_KEY_BY_LABEL_ENTRIES.push([base, entry.key]);
+    FUSE_ARCANA_KEY_BY_LABEL_ENTRIES.push([entry.key.toLowerCase(), entry.key]);
+    if (Array.isArray(entry.aliases)) {
+        for (const alias of entry.aliases) {
+            if (!alias) continue;
+            FUSE_ARCANA_KEY_BY_LABEL_ENTRIES.push([alias.toLowerCase(), entry.key]);
+        }
+    }
+}
+
+export const FUSE_ARCANA_KEY_BY_LABEL = new Map(FUSE_ARCANA_KEY_BY_LABEL_ENTRIES);
+
+export function buildDefaultFusionChart() {
+    const chart = {};
+    for (let row = 0; row < FUSE_ARCANA_ORDER.length; row += 1) {
+        const rowKey = FUSE_ARCANA_ORDER[row];
+        chart[rowKey] = {};
+        for (let col = 0; col < FUSE_ARCANA_ORDER.length; col += 1) {
+            const colKey = FUSE_ARCANA_ORDER[col];
+            const avgIndex = Math.round((row + col) / 2);
+            chart[rowKey][colKey] = FUSE_ARCANA_ORDER[avgIndex];
+        }
+    }
+    return chart;
+}


### PR DESCRIPTION
## Summary
- add a DM-only fusion chart editor with dropdowns and live override handling
- share fusion arcana metadata across client and server and persist overrides via a new API route
- support "None" overrides that randomize results and reflect overrides in the fusion planner UI

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d80b1a72f483319c74b65ee8a127e7