### PR TITLE
Add brush palette customization and map clearing controls

### DIFF
--- a/client/src/api.js
+++ b/client/src/api.js
@@ -647,6 +647,11 @@ export const Games = {
             method: 'DELETE',
             quiet: true,
         }),
+    clearMap: (id) =>
+        api(`/api/games/${encodeURIComponent(id)}/map/clear`, {
+            method: 'POST',
+            quiet: true,
+        }),
     addMapToken: (id, token) =>
         api(`/api/games/${encodeURIComponent(id)}/map/tokens`, {
             method: 'POST',

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -526,6 +526,18 @@ p  { margin: 0 0 .75rem; color: var(--text); }
     margin-top: 8px;
 }
 
+.map-brush-save {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-top: 12px;
+    flex-wrap: wrap;
+}
+
+.map-brush-save label {
+    min-width: 120px;
+}
+
 .map-color {
     width: 28px;
     height: 28px;


### PR DESCRIPTION
## Summary
- allow battle map users to save custom brush colors into palette slots stored locally
- add a clear map endpoint and DM toolbar control with confirmation to wipe the current map state

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d8153511608331a8cfb70a673119bf