### PR TITLE
Add bucket fill tool for battle map backgrounds

### DIFF
--- a/client/src/style.css
+++ b/client/src/style.css
@@ -626,7 +626,8 @@ p  { margin: 0 0 .75rem; color: var(--text); }
     overflow: hidden;
     min-height: 400px;
     border-radius: var(--radius-lg);
-    background: linear-gradient(135deg, rgba(59, 130, 246, 0.06), rgba(59, 130, 246, 0.12));
+    background-color: var(--map-board-color, #0f172a);
+    background-image: linear-gradient(135deg, rgba(59, 130, 246, 0.06), rgba(59, 130, 246, 0.12));
 }
 
 .map-board__background,

--- a/server/server.js
+++ b/server/server.js
@@ -76,6 +76,7 @@ const DEFAULT_SHAPE_STROKE_WIDTH = 2;
 const DEFAULT_SHAPE_OPACITY = 0.6;
 const DEFAULT_BACKGROUND_SCALE = 1;
 const DEFAULT_BACKGROUND_OPACITY = 1;
+const DEFAULT_BACKGROUND_COLOR = '#0f172a';
 const MAP_SHAPE_TYPES = new Set(['rectangle', 'circle', 'line', 'diamond', 'triangle', 'cone', 'image']);
 const MIN_SHAPE_SIZE = 0.02;
 const DEFAULT_DB_PATH = path.join(__dirname, 'data', 'db.json');
@@ -463,6 +464,7 @@ function defaultMapBackground() {
         scale: DEFAULT_BACKGROUND_SCALE,
         rotation: 0,
         opacity: DEFAULT_BACKGROUND_OPACITY,
+        color: DEFAULT_BACKGROUND_COLOR,
     };
 }
 
@@ -481,7 +483,8 @@ function normalizeMapBackground(entry) {
     const rotation = normalizeRotation(entry.rotation);
     const opacityRaw = Number(entry.opacity);
     const opacity = Number.isFinite(opacityRaw) ? Math.min(1, Math.max(0.05, opacityRaw)) : defaults.opacity;
-    return { url, x, y, scale, rotation, opacity };
+    const color = sanitizeColor(entry.color, defaults.color);
+    return { url, x, y, scale, rotation, opacity, color };
 }
 
 function presentMapBackground(background) {
@@ -693,6 +696,13 @@ function applyBackgroundUpdate(map, payload) {
         const value = Number.isFinite(raw) ? Math.min(1, Math.max(0.05, raw)) : target.opacity;
         if (target.opacity !== value) {
             target.opacity = value;
+            changed = true;
+        }
+    }
+    if (Object.prototype.hasOwnProperty.call(payload, 'color')) {
+        const value = sanitizeColor(payload.color, target.color || DEFAULT_BACKGROUND_COLOR);
+        if (target.color !== value) {
+            target.color = value;
             changed = true;
         }
     }


### PR DESCRIPTION
## Summary
- add a DM-only bucket tool that fills the battle map background using saved brush colors
- persist and expose the battle map background color through the map background API
- update map board styling to respect the configured background color

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d83818e0148331b9cc31f9eea6cd4e