### PR TITLE
Allow DMs to adjust player macca

### DIFF
--- a/client/src/api.js
+++ b/client/src/api.js
@@ -557,6 +557,11 @@ export const Games = {
     addCustomItem: (id, item) => api(`/api/games/${encodeURIComponent(id)}/items/custom`, { method: 'POST', body: { item } }),
     updateCustomItem: (id, itemId, item) => api(`/api/games/${encodeURIComponent(id)}/items/custom/${encodeURIComponent(itemId)}`, { method: 'PUT', body: { item } }),
     deleteCustomItem: (id, itemId) => api(`/api/games/${encodeURIComponent(id)}/items/custom/${encodeURIComponent(itemId)}`, { method: 'DELETE' }),
+    adjustPlayerMacca: (id, playerId, delta) =>
+        api(`/api/games/${encodeURIComponent(id)}/players/${encodeURIComponent(playerId)}/macca`, {
+            method: 'POST',
+            body: { delta },
+        }),
     addPlayerItem: (id, playerId, item) => api(`/api/games/${encodeURIComponent(id)}/players/${encodeURIComponent(playerId)}/items`, { method: 'POST', body: { item } }),
     updatePlayerItem: (id, playerId, itemId, item) => api(`/api/games/${encodeURIComponent(id)}/players/${encodeURIComponent(playerId)}/items/${encodeURIComponent(itemId)}`, { method: 'PUT', body: { item } }),
     deletePlayerItem: (id, playerId, itemId) => api(`/api/games/${encodeURIComponent(id)}/players/${encodeURIComponent(playerId)}/items/${encodeURIComponent(itemId)}`, { method: 'DELETE' }),


### PR DESCRIPTION
## Summary
- add a server endpoint that lets DMs adjust a player's macca with validation and auditing
- expose a client API helper and UI controls so the DM can add or remove macca from the inventory tab
- show inline feedback after adjustments and clamp resulting totals to a safe range

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d864c4797c8331b12b37d4987f0500