### PR TITLE
Fix battle map enemy tooltips

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -4390,7 +4390,9 @@ function MapTab({ game, me }) {
                                 dragPreview && dragPreview.kind === 'token' && dragPreview.id === token.id
                                     ? { ...token, x: dragPreview.x, y: dragPreview.y }
                                     : token;
-                            const showTooltip = token.showTooltip && token.tooltip;
+                            const enemyTooltipHasContent =
+                                token.kind === 'enemy' && token.enemyInfo && enemyHasVisibleContent(token.enemyInfo);
+                            const showTooltip = !!token.showTooltip && (!!token.tooltip || enemyTooltipHasContent);
                             const canDrag = canMoveToken(token);
                             const label = token.label || (player ? describePlayerName(player) : demon ? demon.name : 'Marker');
                             return (


### PR DESCRIPTION
## Summary
- ensure battle map enemy tooltips render whenever card content is available

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d8ac5b17f48331916e8d4dac3be375