### PR TITLE
Add DM battle log support for battle map

### DIFF
--- a/client/src/api.js
+++ b/client/src/api.js
@@ -657,6 +657,12 @@ export const Games = {
             method: 'POST',
             quiet: true,
         }),
+    logBattleEvent: (id, entry) =>
+        api(`/api/games/${encodeURIComponent(id)}/map/battle-log`, {
+            method: 'POST',
+            body: entry,
+            quiet: true,
+        }),
     startCombat: (id, payload) =>
         api(`/api/games/${encodeURIComponent(id)}/map/combat/start`, {
             method: 'POST',

--- a/client/src/hooks/useBattleLogger.js
+++ b/client/src/hooks/useBattleLogger.js
@@ -1,0 +1,25 @@
+import { useCallback } from "react";
+
+import { logBattleEvent } from "../utils/battleLogger";
+
+/**
+ * Hook that provides a convenient logger for sending battle map diagnostics to the server.
+ *
+ * @param {string} gameId
+ * @returns {(action: string, message?: string, details?: any) => void}
+ */
+export default function useBattleLogger(gameId) {
+    return useCallback(
+        (action, message, details) => {
+            if (!gameId || !action) return;
+            logBattleEvent(gameId, { action, message, details }).catch((err) => {
+                // Swallow logging failures so they never impact the UX.
+                if (process.env.NODE_ENV !== "production") {
+                    console.debug("battle log failed", err);
+                }
+            });
+        },
+        [gameId],
+    );
+}
+

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -1007,6 +1007,103 @@ p  { margin: 0 0 .75rem; color: var(--text); }
     gap: 16px;
 }
 
+.map-battle-log {
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    background: var(--surface);
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    min-height: 280px;
+    max-height: min(540px, 60vh);
+}
+
+.map-battle-log__header {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.map-battle-log__header h3 {
+    margin: 0;
+    font-size: 1.05rem;
+}
+
+.map-battle-log__scroller {
+    flex: 1;
+    overflow-y: auto;
+    display: grid;
+    gap: 12px;
+    padding-right: 4px;
+}
+
+.map-battle-log__empty {
+    margin: 0;
+    font-size: 0.9rem;
+}
+
+.map-battle-log__entry {
+    display: grid;
+    gap: 6px;
+    padding: 10px 12px;
+    border-radius: var(--radius-sm);
+    background: var(--surface-2);
+    border-left: 3px solid rgba(59, 130, 246, 0.35);
+    box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.16);
+}
+
+.map-battle-log__meta {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--muted);
+}
+
+.map-battle-log__time {
+    font-variant-numeric: tabular-nums;
+}
+
+.map-battle-log__actor {
+    font-weight: 600;
+    color: var(--brand-700);
+}
+
+.map-battle-log__message {
+    font-size: 0.92rem;
+    font-weight: 500;
+}
+
+.map-battle-log__action code {
+    background: rgba(15, 23, 42, 0.08);
+    border-radius: var(--radius-sm);
+    padding: 2px 6px;
+    font-size: 0.75rem;
+    color: var(--muted);
+}
+
+.map-battle-log__details {
+    font-size: 0.8rem;
+}
+
+.map-battle-log__details summary {
+    cursor: pointer;
+    color: var(--brand-700);
+    font-weight: 600;
+    outline: none;
+}
+
+.map-battle-log__details pre {
+    margin: 6px 0 0;
+    padding: 8px;
+    border-radius: var(--radius-sm);
+    background: rgba(15, 23, 42, 0.08);
+    overflow-x: auto;
+}
+
 .map-accordion {
     border: 1px solid var(--border);
     border-radius: var(--radius);

--- a/client/src/utils/battleLogger.js
+++ b/client/src/utils/battleLogger.js
@@ -1,0 +1,36 @@
+import { Games } from "../api";
+
+/**
+ * Dispatch a battle map log entry to the server.
+ *
+ * @param {string} gameId
+ * @param {{ action: string, message?: string, details?: any }} entry
+ */
+export async function logBattleEvent(gameId, entry) {
+    if (!gameId || !entry || typeof entry.action !== "string" || !entry.action.trim()) {
+        return null;
+    }
+
+    const payload = {
+        action: entry.action.trim(),
+        ...(typeof entry.message === "string" && entry.message.trim()
+            ? { message: entry.message.trim() }
+            : {}),
+        ...(entry.details !== undefined ? { details: sanitizeDetails(entry.details) } : {}),
+    };
+
+    return Games.logBattleEvent(gameId, payload);
+}
+
+function sanitizeDetails(details) {
+    if (details === null || details === undefined) return undefined;
+    if (typeof details === "string" || typeof details === "number" || typeof details === "boolean") {
+        return details;
+    }
+    try {
+        return JSON.parse(JSON.stringify(details));
+    } catch {
+        return undefined;
+    }
+}
+


### PR DESCRIPTION
## Summary
- add a DM-only battle log view on the battle map with rich styling and realtime updates
- instrument battle map interactions and settings with a reusable battle logger hook
- persist battle log entries on the server with a new API endpoint and websocket broadcast

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d9792b24108331a92fe0ce3db0b7b2