### PR TITLE
Support per-user combat skill libraries

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -10238,12 +10238,83 @@ function formatDuration(ms) {
     return `${seconds}s`;
 }
 
+function readCombatSkillBucket(collection, ownerId, dmId) {
+    if (!collection) return [];
+    if (Array.isArray(collection)) {
+        if (ownerId && dmId && ownerId === dmId) {
+            return collection;
+        }
+        return [];
+    }
+    if (!ownerId) {
+        const dmBucket = dmId && collection && typeof collection === 'object' ? collection[dmId] : null;
+        return Array.isArray(dmBucket) ? dmBucket : [];
+    }
+    if (collection && typeof collection === 'object') {
+        const bucket = collection[ownerId];
+        if (Array.isArray(bucket)) return bucket;
+    }
+    return [];
+}
+
 // ---------- Items ----------
 
 function CombatSkillsTab({ game, me, onUpdate }) {
     const isDM = game.dmId === me.id;
     const abilityDefault = ABILITY_DEFS[0]?.key || "INT";
-    const combatSkills = useMemo(() => normalizeCombatSkillDefs(game.combatSkills), [game.combatSkills]);
+    const ownerOptions = useMemo(() => {
+        const options = [];
+        const seen = new Set();
+        const addOption = (value, label) => {
+            if (!value || seen.has(value)) return;
+            seen.add(value);
+            options.push({ value, label });
+        };
+        const players = Array.isArray(game.players) ? game.players.filter(Boolean) : [];
+        if (isDM && typeof game.dmId === "string" && game.dmId) {
+            const dmLabel = game.dmId === me.id
+                ? `You (${me.username || "Dungeon Master"})`
+                : "Dungeon Master";
+            addOption(game.dmId, dmLabel);
+        }
+        for (const player of players) {
+            if (!player?.userId) continue;
+            if (!isDM && player.userId !== me.id) continue;
+            const baseLabel = describePlayerName(player);
+            const label = player.userId === me.id ? `You (${baseLabel})` : baseLabel;
+            addOption(player.userId, label);
+        }
+        if (!isDM && me?.id && !seen.has(me.id)) {
+            const fallbackLabel = me.username ? `You (${me.username})` : "You";
+            addOption(me.id, fallbackLabel);
+        }
+        return options;
+    }, [game.dmId, game.players, isDM, me?.id, me?.username]);
+    const defaultOwnerId = useMemo(() => {
+        if (ownerOptions.length > 0) return ownerOptions[0].value;
+        if (isDM && typeof game.dmId === "string" && game.dmId) return game.dmId;
+        if (me?.id) return me.id;
+        return "";
+    }, [game.dmId, isDM, me?.id, ownerOptions]);
+    const [activeOwnerId, setActiveOwnerId] = useState(defaultOwnerId);
+    useEffect(() => {
+        if (ownerOptions.length === 0) {
+            setActiveOwnerId("");
+            return;
+        }
+        setActiveOwnerId((prev) => {
+            if (prev && ownerOptions.some((option) => option.value === prev)) {
+                return prev;
+            }
+            return defaultOwnerId;
+        });
+    }, [defaultOwnerId, ownerOptions]);
+    const activeOwnerValue = activeOwnerId || defaultOwnerId;
+    const rawCombatSkills = useMemo(
+        () => readCombatSkillBucket(game.combatSkills, activeOwnerValue, game.dmId),
+        [game.combatSkills, activeOwnerValue, game.dmId],
+    );
+    const combatSkills = useMemo(() => normalizeCombatSkillDefs(rawCombatSkills), [rawCombatSkills]);
     const worldSkills = useMemo(() => normalizeWorldSkillDefs(game.worldSkills), [game.worldSkills]);
     const demons = useMemo(
         () => (Array.isArray(game.demons) ? game.demons.filter(Boolean) : EMPTY_ARRAY),
@@ -10266,10 +10337,10 @@ function CombatSkillsTab({ game, me, onUpdate }) {
     const [rowBusy, setRowBusy] = useState(null);
     const [importBusyId, setImportBusyId] = useState(null);
     const skillLibraryDatalistId = "combat-skill-library-options";
-    const viewPrefKey = useMemo(
-        () => `combat-skill-view:${game.id || "game"}:${me.id || "user"}`,
-        [game.id, me.id]
-    );
+    const viewPrefKey = useMemo(() => {
+        const ownerKey = activeOwnerValue || me.id || game.dmId || "owner";
+        return `combat-skill-view:${game.id || "game"}:${ownerKey}`;
+    }, [activeOwnerValue, game.dmId, game.id, me.id]);
     const [viewPrefs, setViewPrefs] = useState(() => createEmptySkillViewPrefs());
     const [showHiddenSkills, setShowHiddenSkills] = useState(false);
     const canManage = isDM || !!game.permissions?.canEditCombatSkills;
@@ -10289,7 +10360,7 @@ function CombatSkillsTab({ game, me, onUpdate }) {
         });
         setActivePane("library");
         setShowHiddenSkills(false);
-    }, [game.id, abilityDefault]);
+    }, [abilityDefault, activeOwnerValue, game.id]);
 
     const editingSkill = useMemo(() => {
         if (!editingSkillId || editingSkillId === NEW_COMBAT_SKILL_ID) return null;
@@ -10551,6 +10622,7 @@ function CombatSkillsTab({ game, me, onUpdate }) {
             alert("Skill needs a name");
             return;
         }
+        const ownerIdForRequest = activeOwnerValue || defaultOwnerId || (isDM ? game.dmId : me.id) || null;
         const payload = {
             label,
             ability: ABILITY_KEY_SET.has(form.ability) ? form.ability : abilityDefault,
@@ -10565,10 +10637,19 @@ function CombatSkillsTab({ game, me, onUpdate }) {
         try {
             if (editingSkillId === NEW_COMBAT_SKILL_ID) {
                 setBusy(true);
-                await Games.addCombatSkill(game.id, payload);
+                await Games.addCombatSkill(
+                    game.id,
+                    payload,
+                    ownerIdForRequest ? { userId: ownerIdForRequest } : undefined,
+                );
             } else if (editingSkill) {
                 setRowBusy(editingSkill.id);
-                await Games.updateCombatSkill(game.id, editingSkill.id, payload);
+                await Games.updateCombatSkill(
+                    game.id,
+                    editingSkill.id,
+                    payload,
+                    ownerIdForRequest ? { userId: ownerIdForRequest } : undefined,
+                );
             }
             setEditingSkillId(null);
             await onUpdate?.();
@@ -10578,16 +10659,34 @@ function CombatSkillsTab({ game, me, onUpdate }) {
             setBusy(false);
             setRowBusy(null);
         }
-    }, [abilityDefault, canManage, editingSkill, editingSkillId, form, game.id, onUpdate]);
+    }, [
+        abilityDefault,
+        activeOwnerValue,
+        canManage,
+        defaultOwnerId,
+        editingSkill,
+        editingSkillId,
+        form,
+        game.dmId,
+        game.id,
+        isDM,
+        me.id,
+        onUpdate,
+    ]);
 
     const handleDelete = useCallback(
         async (skill) => {
             if (!canManage || !skill) return;
             const confirmed = confirm(`Delete ${skill.label}? This cannot be undone.`);
             if (!confirmed) return;
+            const ownerIdForRequest = activeOwnerValue || defaultOwnerId || (isDM ? game.dmId : me.id) || null;
             try {
                 setRowBusy(skill.id);
-                await Games.deleteCombatSkill(game.id, skill.id);
+                await Games.deleteCombatSkill(
+                    game.id,
+                    skill.id,
+                    ownerIdForRequest ? { userId: ownerIdForRequest } : undefined,
+                );
                 await onUpdate?.();
             } catch (err) {
                 alert(err?.message || "Failed to delete combat skill");
@@ -10595,12 +10694,13 @@ function CombatSkillsTab({ game, me, onUpdate }) {
                 setRowBusy(null);
             }
         },
-        [canManage, game.id, onUpdate]
+        [activeOwnerValue, canManage, defaultOwnerId, game.dmId, game.id, isDM, me.id, onUpdate]
     );
 
     const importGlossarySkill = useCallback(
         async (entry) => {
             if (!canManage || !entry || typeof entry.label !== "string") return;
+            const ownerIdForRequest = activeOwnerValue || defaultOwnerId || (isDM ? game.dmId : me.id) || null;
             const payload = {
                 label: entry.label,
                 ability: ABILITY_KEY_SET.has(entry.ability) ? entry.ability : abilityDefault,
@@ -10612,7 +10712,11 @@ function CombatSkillsTab({ game, me, onUpdate }) {
             };
             try {
                 setImportBusyId(entry.id);
-                await Games.addCombatSkill(game.id, payload);
+                await Games.addCombatSkill(
+                    game.id,
+                    payload,
+                    ownerIdForRequest ? { userId: ownerIdForRequest } : undefined,
+                );
                 await onUpdate?.();
             } catch (err) {
                 alert(err?.message || "Failed to import skill");
@@ -10620,7 +10724,17 @@ function CombatSkillsTab({ game, me, onUpdate }) {
                 setImportBusyId(null);
             }
         },
-        [abilityDefault, canManage, game.id, onUpdate]
+        [
+            abilityDefault,
+            activeOwnerValue,
+            canManage,
+            defaultOwnerId,
+            game.dmId,
+            game.id,
+            isDM,
+            me.id,
+            onUpdate,
+        ]
     );
 
     const renderSkillEditor = (mode) => {
@@ -10814,6 +10928,21 @@ function CombatSkillsTab({ game, me, onUpdate }) {
                 {activePane === "library" ? (
                     <>
                         <div className="combat-skill-manager__filters row wrap">
+                            {isDM && ownerOptions.length > 0 && (
+                                <label className="text-small" style={{ minWidth: 200 }}>
+                                    Managing skills for
+                                    <select
+                                        value={activeOwnerValue}
+                                        onChange={(e) => setActiveOwnerId(e.target.value)}
+                                    >
+                                        {ownerOptions.map((option) => (
+                                            <option key={option.value} value={option.value}>
+                                                {option.label}
+                                            </option>
+                                        ))}
+                                    </select>
+                                </label>
+                            )}
                             <label className="text-small" style={{ flexGrow: 1 }}>
                                 Search
                                 <input

--- a/client/src/api.js
+++ b/client/src/api.js
@@ -536,15 +536,30 @@ export const Games = {
     joinByCode: (code) => api(`/api/games/join/${encodeURIComponent(code)}`, { method: 'POST' }),
     setPerms: (id, perms) => api(`/api/games/${encodeURIComponent(id)}/permissions`, { method: 'PUT', body: perms }),
     saveCharacter: (id, character) => api(`/api/games/${encodeURIComponent(id)}/character`, { method: 'PUT', body: { character } }),
-    addCombatSkill: (id, skill) =>
-        api(`/api/games/${encodeURIComponent(id)}/combat-skills`, { method: 'POST', body: { skill } }),
-    updateCombatSkill: (id, skillId, skill) =>
-        api(`/api/games/${encodeURIComponent(id)}/combat-skills/${encodeURIComponent(skillId)}`, {
+    addCombatSkill: (id, skill, options = {}) => {
+        const targetUserId =
+            typeof options.userId === 'string' && options.userId.trim() ? options.userId.trim() : null;
+        const body = targetUserId ? { skill, targetUserId } : { skill };
+        return api(`/api/games/${encodeURIComponent(id)}/combat-skills`, { method: 'POST', body });
+    },
+    updateCombatSkill: (id, skillId, skill, options = {}) => {
+        const targetUserId =
+            typeof options.userId === 'string' && options.userId.trim() ? options.userId.trim() : null;
+        const body = targetUserId ? { skill, targetUserId } : { skill };
+        return api(`/api/games/${encodeURIComponent(id)}/combat-skills/${encodeURIComponent(skillId)}`, {
             method: 'PUT',
-            body: { skill },
-        }),
-    deleteCombatSkill: (id, skillId) =>
-        api(`/api/games/${encodeURIComponent(id)}/combat-skills/${encodeURIComponent(skillId)}`, { method: 'DELETE' }),
+            body,
+        });
+    },
+    deleteCombatSkill: (id, skillId, options = {}) => {
+        const targetUserId =
+            typeof options.userId === 'string' && options.userId.trim() ? options.userId.trim() : null;
+        const request = { method: 'DELETE' };
+        if (targetUserId) {
+            request.body = { targetUserId };
+        }
+        return api(`/api/games/${encodeURIComponent(id)}/combat-skills/${encodeURIComponent(skillId)}`, request);
+    },
     addWorldSkill: (id, skill) =>
         api(`/api/games/${encodeURIComponent(id)}/world-skills`, { method: 'POST', body: { skill } }),
     updateWorldSkill: (id, skillId, skill) =>

--- a/client/src/constants/gameData.js
+++ b/client/src/constants/gameData.js
@@ -557,7 +557,17 @@ export function normalizeWorldSkillDefs(raw) {
 }
 
 export function normalizeCombatSkillDefs(raw) {
-    const source = Array.isArray(raw) ? raw : [];
+    let source = [];
+    if (Array.isArray(raw)) {
+        source = raw;
+    } else if (raw && typeof raw === "object") {
+        source = Object.values(raw).reduce((acc, value) => {
+            if (Array.isArray(value)) {
+                acc.push(...value);
+            }
+            return acc;
+        }, []);
+    }
     const seen = new Set();
     const normalized = [];
     for (const entry of source) {


### PR DESCRIPTION
## Summary
- store combat skills per game member and resolve the target owner for create/update/delete operations
- expose per-player combat skill lists in the UI with a DM selector and reuse view preferences per owner
- allow API calls to specify the skill owner and normalize combat skill data coming from the server map

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d999720918833199f42fef7ce2297a