### PR TITLE
Add admin server management tools

### DIFF
--- a/client/src/api.js
+++ b/client/src/api.js
@@ -519,9 +519,9 @@ export const Auth = {
         body: { username, password },
         noRetry: true,
     }),
-    register: (username, password) => api('/api/auth/register', {
+    register: (username, password, email, confirmPassword) => api('/api/auth/register', {
         method: 'POST',
-        body: { username, password },
+        body: { username, password, email, confirmPassword },
         noRetry: true,
     }),
     logout: () => api('/api/auth/logout', { method: 'POST', noRetry: true }),
@@ -720,6 +720,37 @@ export const Games = {
 
     // Optional: full pagination helper example if the backend supports it
     listAll: (query) => apiClient.getAllPages('/api/games', { query }),
+};
+
+export const ServerAdmin = {
+    users: {
+        list: () => api('/api/admin/users'),
+        update: (id, payload) =>
+            api(`/api/admin/users/${encodeURIComponent(id)}`, { method: 'PATCH', body: payload }),
+        delete: (id) => api(`/api/admin/users/${encodeURIComponent(id)}`, { method: 'DELETE' }),
+    },
+    games: {
+        list: () => api('/api/admin/games'),
+        delete: (id) => api(`/api/admin/games/${encodeURIComponent(id)}`, { method: 'DELETE' }),
+        removePlayer: (gameId, playerId) =>
+            api(
+                `/api/admin/games/${encodeURIComponent(gameId)}/players/${encodeURIComponent(playerId)}`,
+                { method: 'DELETE' },
+            ),
+        setDungeonMaster: (gameId, dmId) =>
+            api(`/api/admin/games/${encodeURIComponent(gameId)}`, { method: 'PATCH', body: { dmId } }),
+    },
+    demons: {
+        list: () => api('/api/admin/demons'),
+        update: (id, payload) =>
+            api(`/api/admin/demons/${encodeURIComponent(id)}`, { method: 'PATCH', body: payload }),
+        uploadCsv: (csv) => api('/api/admin/demons/upload', { method: 'POST', body: { csv } }),
+        sync: () => api('/api/admin/demons/sync', { method: 'POST' }),
+    },
+    masterBot: {
+        get: () => api('/api/admin/master-bot', { cache: 2000 }),
+        update: (settings) => api('/api/admin/master-bot', { method: 'PUT', body: settings }),
+    },
 };
 
 export const Items = {

--- a/client/src/components/ServerManagementTab.jsx
+++ b/client/src/components/ServerManagementTab.jsx
@@ -1,0 +1,870 @@
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { ServerAdmin } from "../api";
+
+const SUBTABS = [
+    { key: "users", label: "Users" },
+    { key: "games", label: "Games" },
+    { key: "demons", label: "Default Demons" },
+    { key: "bot", label: "Master Discord Bot" },
+];
+
+function formatError(err) {
+    if (!err) return "";
+    if (typeof err === "string") return err;
+    if (err instanceof Error) return err.message;
+    return err?.message || "Unexpected error";
+}
+
+function UsersAdminPanel({ onChanged }) {
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState("");
+    const [users, setUsers] = useState([]);
+    const [drafts, setDrafts] = useState({});
+
+    const load = useCallback(async () => {
+        setLoading(true);
+        setError("");
+        try {
+            const list = await ServerAdmin.users.list();
+            setUsers(Array.isArray(list) ? list : []);
+            setDrafts({});
+        } catch (err) {
+            setError(formatError(err));
+        } finally {
+            setLoading(false);
+        }
+    }, []);
+
+    useEffect(() => {
+        load();
+    }, [load]);
+
+    const getDraft = (user) => {
+        const base = drafts[user.id];
+        if (base) return base;
+        return {
+            username: user.username || "",
+            email: user.email || "",
+            banned: !!user.banned,
+        };
+    };
+
+    const updateDraft = (user, changes) => {
+        setDrafts((prev) => ({
+            ...prev,
+            [user.id]: { ...getDraft(user), ...(prev[user.id] || {}), ...changes },
+        }));
+    };
+
+    const handleSave = async (user) => {
+        const draft = getDraft(user);
+        const payload = {
+            username: draft.username.trim(),
+            email: draft.email.trim(),
+            banned: !!draft.banned,
+        };
+        try {
+            const updated = await ServerAdmin.users.update(user.id, payload);
+            setUsers((prev) => prev.map((item) => (item.id === user.id ? updated : item)));
+            setDrafts((prev) => {
+                const next = { ...prev };
+                delete next[user.id];
+                return next;
+            });
+            if (typeof onChanged === "function") onChanged();
+        } catch (err) {
+            alert(formatError(err));
+        }
+    };
+
+    const handleDelete = async (user) => {
+        if (!window.confirm(`Delete user "${user.username}"? This will remove them from all games.`)) {
+            return;
+        }
+        try {
+            await ServerAdmin.users.delete(user.id);
+            setUsers((prev) => prev.filter((item) => item.id !== user.id));
+            setDrafts((prev) => {
+                const next = { ...prev };
+                delete next[user.id];
+                return next;
+            });
+            if (typeof onChanged === "function") onChanged();
+        } catch (err) {
+            alert(formatError(err));
+        }
+    };
+
+    const renderUser = (user) => {
+        const draft = getDraft(user);
+        const originalEmail = user.email || "";
+        const dirty =
+            draft.username.trim() !== (user.username || "") ||
+            draft.email.trim() !== originalEmail ||
+            !!draft.banned !== !!user.banned;
+
+        return (
+            <div key={user.id} className="card" style={{ padding: 16, gap: 12 }}>
+                <div className="row" style={{ alignItems: "center", gap: 12 }}>
+                    <h3 style={{ margin: 0 }}>{user.username}</h3>
+                    {user.email && (
+                        <span className="text-muted">{user.email}</span>
+                    )}
+                    {user.banned && <span className="pill danger">Banned</span>}
+                </div>
+                <div className="grid" style={{ gap: 12 }}>
+                    <label className="col">
+                        <span className="text-muted text-small">Username</span>
+                        <input
+                            value={draft.username}
+                            onChange={(e) => updateDraft(user, { username: e.target.value })}
+                        />
+                    </label>
+                    <label className="col">
+                        <span className="text-muted text-small">Email</span>
+                        <input
+                            value={draft.email}
+                            onChange={(e) => updateDraft(user, { email: e.target.value })}
+                        />
+                    </label>
+                    <label className="row" style={{ alignItems: "center", gap: 8 }}>
+                        <input
+                            type="checkbox"
+                            checked={draft.banned}
+                            onChange={(e) => updateDraft(user, { banned: e.target.checked })}
+                        />
+                        <span>Banned</span>
+                    </label>
+                </div>
+                <div className="row" style={{ gap: 8 }}>
+                    <button
+                        type="button"
+                        className="btn"
+                        onClick={() => handleSave(user)}
+                        disabled={!dirty}
+                    >
+                        Save
+                    </button>
+                    <button
+                        type="button"
+                        className="btn ghost"
+                        onClick={() => setDrafts((prev) => {
+                            const next = { ...prev };
+                            delete next[user.id];
+                            return next;
+                        })}
+                        disabled={!drafts[user.id]}
+                    >
+                        Reset
+                    </button>
+                    <button
+                        type="button"
+                        className="btn danger"
+                        onClick={() => handleDelete(user)}
+                    >
+                        Delete
+                    </button>
+                </div>
+            </div>
+        );
+    };
+
+    return (
+        <div className="col" style={{ gap: 16 }}>
+            <div className="row" style={{ justifyContent: "space-between", alignItems: "center" }}>
+                <h2 style={{ margin: 0 }}>User Directory</h2>
+                <button type="button" className="btn ghost" onClick={load} disabled={loading}>
+                    {loading ? "Loading…" : "Refresh"}
+                </button>
+            </div>
+            {error && <div className="alert warn">{error}</div>}
+            {loading && users.length === 0 ? (
+                <div className="text-muted">Loading users…</div>
+            ) : users.length === 0 ? (
+                <div className="text-muted">No users found.</div>
+            ) : (
+                <div className="col" style={{ gap: 12 }}>
+                    {users.map((user) => renderUser(user))}
+                </div>
+            )}
+        </div>
+    );
+}
+
+function GamesAdminPanel({ activeGameId, onGameDeleted, onRefreshGames, onRefreshActiveGame }) {
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState("");
+    const [games, setGames] = useState([]);
+
+    const load = useCallback(async () => {
+        setLoading(true);
+        setError("");
+        try {
+            const list = await ServerAdmin.games.list();
+            setGames(Array.isArray(list) ? list : []);
+        } catch (err) {
+            setError(formatError(err));
+        } finally {
+            setLoading(false);
+        }
+    }, []);
+
+    useEffect(() => {
+        load();
+    }, [load]);
+
+    const refreshAll = useCallback(async () => {
+        await load();
+        if (typeof onRefreshGames === "function") await onRefreshGames();
+    }, [load, onRefreshGames]);
+
+    const handleDeleteGame = async (game) => {
+        if (!window.confirm(`Delete the game "${game.name}"? This cannot be undone.`)) {
+            return;
+        }
+        try {
+            await ServerAdmin.games.delete(game.id);
+            if (game.id === activeGameId && typeof onGameDeleted === "function") {
+                await onGameDeleted();
+            }
+            await refreshAll();
+        } catch (err) {
+            alert(formatError(err));
+        }
+    };
+
+    const handleRemovePlayer = async (game, playerId) => {
+        if (!playerId) return;
+        try {
+            await ServerAdmin.games.removePlayer(game.id, playerId);
+            if (game.id === activeGameId && typeof onRefreshActiveGame === "function") {
+                await onRefreshActiveGame();
+            }
+            await refreshAll();
+        } catch (err) {
+            alert(formatError(err));
+        }
+    };
+
+    const handleSetDm = async (game, dmId) => {
+        if (!dmId) return;
+        try {
+            await ServerAdmin.games.setDungeonMaster(game.id, dmId);
+            if (game.id === activeGameId && typeof onRefreshActiveGame === "function") {
+                await onRefreshActiveGame();
+            }
+            await refreshAll();
+        } catch (err) {
+            alert(formatError(err));
+        }
+    };
+
+    const renderGame = (game) => {
+        const players = Array.isArray(game.players) ? game.players : [];
+        return (
+            <div key={game.id} className="card" style={{ padding: 16, gap: 12 }}>
+                <div className="row" style={{ justifyContent: "space-between", alignItems: "baseline" }}>
+                    <div>
+                        <h3 style={{ margin: 0 }}>{game.name}</h3>
+                        <p className="text-muted" style={{ margin: 0 }}>
+                            DM: {game.dmUsername || game.dmId || "Unassigned"}
+                        </p>
+                        <p className="text-muted" style={{ margin: 0 }}>
+                            Players: {players.length}
+                        </p>
+                    </div>
+                    <button type="button" className="btn danger" onClick={() => handleDeleteGame(game)}>
+                        Delete Game
+                    </button>
+                </div>
+                <div className="col" style={{ gap: 8 }}>
+                    <div className="row" style={{ gap: 8, alignItems: "center" }}>
+                        <label className="row" style={{ gap: 8, alignItems: "center" }}>
+                            <span className="text-muted text-small">Remove player</span>
+                            <select
+                                onChange={(e) => {
+                                    const value = e.target.value;
+                                    if (value) handleRemovePlayer(game, value);
+                                    e.target.value = "";
+                                }}
+                                defaultValue=""
+                            >
+                                <option value="">Select player…</option>
+                                {players
+                                    .filter((p) => p && p.userId !== game.dmId)
+                                    .map((player) => (
+                                        <option key={player.userId} value={player.userId}>
+                                            {player.username || player.userId}
+                                        </option>
+                                    ))}
+                            </select>
+                        </label>
+                        <label className="row" style={{ gap: 8, alignItems: "center" }}>
+                            <span className="text-muted text-small">Change DM</span>
+                            <select
+                                onChange={(e) => {
+                                    const value = e.target.value;
+                                    if (value) handleSetDm(game, value);
+                                    e.target.value = "";
+                                }}
+                                defaultValue=""
+                            >
+                                <option value="">Select new DM…</option>
+                                {players.map((player) => (
+                                    <option key={player.userId} value={player.userId}>
+                                        {player.username || player.userId}
+                                        {player.userId === game.dmId ? " (current)" : ""}
+                                    </option>
+                                ))}
+                            </select>
+                        </label>
+                    </div>
+                </div>
+            </div>
+        );
+    };
+
+    return (
+        <div className="col" style={{ gap: 16 }}>
+            <div className="row" style={{ justifyContent: "space-between", alignItems: "center" }}>
+                <h2 style={{ margin: 0 }}>Games</h2>
+                <button type="button" className="btn ghost" onClick={refreshAll} disabled={loading}>
+                    {loading ? "Loading…" : "Refresh"}
+                </button>
+            </div>
+            {error && <div className="alert warn">{error}</div>}
+            {loading && games.length === 0 ? (
+                <div className="text-muted">Loading games…</div>
+            ) : games.length === 0 ? (
+                <div className="text-muted">No games found.</div>
+            ) : (
+                <div className="col" style={{ gap: 12 }}>
+                    {games.map((game) => renderGame(game))}
+                </div>
+            )}
+        </div>
+    );
+}
+
+function createDemonDraft(demon) {
+    if (!demon) {
+        return {
+            arcana: "",
+            level: "",
+            alignment: "",
+            personality: "",
+            description: "",
+            skillsText: "",
+            resistances: {
+                weak: "",
+                resist: "",
+                block: "",
+                drain: "",
+                reflect: "",
+            },
+        };
+    }
+    const resist = demon.resistances || {};
+    return {
+        arcana: demon.arcana || "",
+        level: demon.level ?? "",
+        alignment: demon.alignment || "",
+        personality: demon.personality || "",
+        description: demon.description || "",
+        skillsText: Array.isArray(demon.skills) ? demon.skills.join(", ") : "",
+        resistances: {
+            weak: Array.isArray(resist.weak) ? resist.weak.join(", ") : "",
+            resist: Array.isArray(resist.resist) ? resist.resist.join(", ") : "",
+            block: Array.isArray(resist.block) ? resist.block.join(", ") : "",
+            drain: Array.isArray(resist.drain) ? resist.drain.join(", ") : "",
+            reflect: Array.isArray(resist.reflect) ? resist.reflect.join(", ") : "",
+        },
+    };
+}
+
+function DemonsAdminPanel() {
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState("");
+    const [demons, setDemons] = useState([]);
+    const [search, setSearch] = useState("");
+    const [selectedId, setSelectedId] = useState(null);
+    const [draft, setDraft] = useState(null);
+    const [csvReport, setCsvReport] = useState(null);
+
+    const load = useCallback(async () => {
+        setLoading(true);
+        setError("");
+        try {
+            const list = await ServerAdmin.demons.list();
+            setDemons(Array.isArray(list) ? list : []);
+        } catch (err) {
+            setError(formatError(err));
+        } finally {
+            setLoading(false);
+        }
+    }, []);
+
+    useEffect(() => {
+        load();
+    }, [load]);
+
+    useEffect(() => {
+        const demon = demons.find((entry) => Number(entry?.id) === Number(selectedId));
+        setDraft(createDemonDraft(demon));
+    }, [demons, selectedId]);
+
+    const filteredDemons = useMemo(() => {
+        if (!search) return demons;
+        const term = search.toLowerCase();
+        return demons.filter((demon) =>
+            (demon.name || "").toLowerCase().includes(term) ||
+            (demon.arcana || "").toLowerCase().includes(term),
+        );
+    }, [demons, search]);
+
+    const selectedDemon = useMemo(
+        () => demons.find((entry) => Number(entry?.id) === Number(selectedId)) || null,
+        [demons, selectedId],
+    );
+
+    const handleSelectDemon = (id) => {
+        setSelectedId(id);
+    };
+
+    const handleDraftChange = (changes) => {
+        setDraft((prev) => ({
+            ...(prev || {}),
+            ...changes,
+        }));
+    };
+
+    const handleResistanceChange = (key, value) => {
+        setDraft((prev) => ({
+            ...(prev || {}),
+            resistances: {
+                ...(prev?.resistances || {}),
+                [key]: value,
+            },
+        }));
+    };
+
+    const handleSave = async () => {
+        if (!selectedDemon || !draft) return;
+        const parsedLevel = Number(draft.level);
+        const payload = {
+            arcana: draft.arcana,
+            level:
+                draft.level === ""
+                    ? null
+                    : Number.isFinite(parsedLevel)
+                    ? parsedLevel
+                    : selectedDemon.level,
+            alignment: draft.alignment,
+            personality: draft.personality,
+            description: draft.description,
+            skills: draft.skillsText
+                ? draft.skillsText
+                      .split(",")
+                      .map((item) => item.trim())
+                      .filter(Boolean)
+                : [],
+            resistances: {
+                weak: draft.resistances?.weak
+                    ? draft.resistances.weak.split(",").map((item) => item.trim()).filter(Boolean)
+                    : [],
+                resist: draft.resistances?.resist
+                    ? draft.resistances.resist.split(",").map((item) => item.trim()).filter(Boolean)
+                    : [],
+                block: draft.resistances?.block
+                    ? draft.resistances.block.split(",").map((item) => item.trim()).filter(Boolean)
+                    : [],
+                drain: draft.resistances?.drain
+                    ? draft.resistances.drain.split(",").map((item) => item.trim()).filter(Boolean)
+                    : [],
+                reflect: draft.resistances?.reflect
+                    ? draft.resistances.reflect.split(",").map((item) => item.trim()).filter(Boolean)
+                    : [],
+            },
+        };
+        try {
+            const updated = await ServerAdmin.demons.update(selectedDemon.id, payload);
+            setDemons((prev) => prev.map((entry) => (entry.id === updated.id ? updated : entry)));
+            alert("Demon updated");
+        } catch (err) {
+            alert(formatError(err));
+        }
+    };
+
+    const handleReset = () => {
+        const demon = demons.find((entry) => Number(entry?.id) === Number(selectedId));
+        setDraft(createDemonDraft(demon));
+    };
+
+    const handleCsvUpload = async (file) => {
+        if (!file) return;
+        try {
+            const text = await file.text();
+            const report = await ServerAdmin.demons.uploadCsv(text);
+            setCsvReport(report);
+            if (report?.wrote) {
+                await load();
+            }
+            if (report?.demonsUpdated > 0 && window.confirm("Testing - passed, push to database?")) {
+                const sync = await ServerAdmin.demons.sync();
+                setCsvReport((prev) => ({ ...prev, synced: sync?.count ?? 0 }));
+            }
+        } catch (err) {
+            alert(formatError(err));
+        }
+    };
+
+    return (
+        <div className="col" style={{ gap: 16 }}>
+            <div className="row" style={{ justifyContent: "space-between", alignItems: "center" }}>
+                <h2 style={{ margin: 0 }}>Default Demons</h2>
+                <label className="btn ghost">
+                    Upload CSV
+                    <input
+                        type="file"
+                        accept=".csv,text/csv"
+                        style={{ display: "none" }}
+                        onChange={(e) => {
+                            const file = e.target.files?.[0];
+                            if (file) handleCsvUpload(file);
+                            e.target.value = "";
+                        }}
+                    />
+                </label>
+            </div>
+            {error && <div className="alert warn">{error}</div>}
+            <div className="row" style={{ gap: 12 }}>
+                <input
+                    placeholder="Search demons"
+                    value={search}
+                    onChange={(e) => setSearch(e.target.value)}
+                />
+                <button type="button" className="btn ghost" onClick={load} disabled={loading}>
+                    {loading ? "Loading…" : "Refresh"}
+                </button>
+            </div>
+            <div className="row" style={{ gap: 16 }}>
+                <div style={{ flex: "0 0 260px", maxHeight: 360, overflow: "auto" }}>
+                    {loading && demons.length === 0 ? (
+                        <div className="text-muted">Loading demons…</div>
+                    ) : filteredDemons.length === 0 ? (
+                        <div className="text-muted">No demons match your search.</div>
+                    ) : (
+                        <ul className="col" style={{ listStyle: "none", margin: 0, padding: 0, gap: 4 }}>
+                            {filteredDemons.map((demon) => (
+                                <li key={demon.id}>
+                                    <button
+                                        type="button"
+                                        className={`btn ghost btn-small${selectedId === demon.id ? " is-active" : ""}`}
+                                        onClick={() => handleSelectDemon(demon.id)}
+                                    >
+                                        {demon.name} <span className="text-muted">({demon.arcana})</span>
+                                    </button>
+                                </li>
+                            ))}
+                        </ul>
+                    )}
+                </div>
+                <div style={{ flex: 1 }}>
+                    {!selectedDemon ? (
+                        <div className="text-muted">Select a demon to edit.</div>
+                    ) : (
+                        <div className="col" style={{ gap: 12 }}>
+                            <h3 style={{ margin: 0 }}>{selectedDemon.name}</h3>
+                            <div className="grid" style={{ gap: 12, gridTemplateColumns: "repeat(auto-fit, minmax(200px, 1fr))" }}>
+                                <label className="col">
+                                    <span className="text-muted text-small">Arcana</span>
+                                    <input
+                                        value={draft?.arcana || ""}
+                                        onChange={(e) => handleDraftChange({ arcana: e.target.value })}
+                                    />
+                                </label>
+                                <label className="col">
+                                    <span className="text-muted text-small">Level</span>
+                                    <input
+                                        value={draft?.level ?? ""}
+                                        onChange={(e) => handleDraftChange({ level: e.target.value })}
+                                    />
+                                </label>
+                                <label className="col">
+                                    <span className="text-muted text-small">Alignment</span>
+                                    <input
+                                        value={draft?.alignment || ""}
+                                        onChange={(e) => handleDraftChange({ alignment: e.target.value })}
+                                    />
+                                </label>
+                                <label className="col">
+                                    <span className="text-muted text-small">Personality</span>
+                                    <input
+                                        value={draft?.personality || ""}
+                                        onChange={(e) => handleDraftChange({ personality: e.target.value })}
+                                    />
+                                </label>
+                            </div>
+                            <label className="col">
+                                <span className="text-muted text-small">Description</span>
+                                <textarea
+                                    rows={4}
+                                    value={draft?.description || ""}
+                                    onChange={(e) => handleDraftChange({ description: e.target.value })}
+                                />
+                            </label>
+                            <label className="col">
+                                <span className="text-muted text-small">Skills (comma separated)</span>
+                                <textarea
+                                    rows={2}
+                                    value={draft?.skillsText || ""}
+                                    onChange={(e) => handleDraftChange({ skillsText: e.target.value })}
+                                />
+                            </label>
+                            <div className="grid" style={{ gap: 12, gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))" }}>
+                                {[
+                                    ["weak", "Weak"],
+                                    ["resist", "Resist"],
+                                    ["block", "Block/Null"],
+                                    ["drain", "Drain"],
+                                    ["reflect", "Reflect"],
+                                ].map(([key, label]) => (
+                                    <label key={key} className="col">
+                                        <span className="text-muted text-small">{label}</span>
+                                        <textarea
+                                            rows={2}
+                                            value={draft?.resistances?.[key] || ""}
+                                            onChange={(e) => handleResistanceChange(key, e.target.value)}
+                                        />
+                                    </label>
+                                ))}
+                            </div>
+                            <div className="row" style={{ gap: 8 }}>
+                                <button type="button" className="btn" onClick={handleSave}>
+                                    Save Changes
+                                </button>
+                                <button type="button" className="btn ghost" onClick={handleReset}>
+                                    Reset
+                                </button>
+                            </div>
+                        </div>
+                    )}
+                </div>
+            </div>
+            {csvReport && (
+                <div className="card" style={{ padding: 16, gap: 8 }}>
+                    <strong>CSV Import Summary</strong>
+                    <div>Rows processed: {csvReport.rowsProcessed}</div>
+                    <div>Demons updated: {csvReport.demonsUpdated}</div>
+                    {Array.isArray(csvReport.warnings) && csvReport.warnings.length > 0 && (
+                        <div className="alert warn" style={{ marginTop: 8 }}>
+                            <strong>Warnings</strong>
+                            <ul style={{ margin: '8px 0 0 16px' }}>
+                                {csvReport.warnings.map((message, idx) => (
+                                    <li key={idx}>{message}</li>
+                                ))}
+                            </ul>
+                        </div>
+                    )}
+                    {csvReport.backupPath && (
+                        <div className="text-muted">Backup: {csvReport.backupPath}</div>
+                    )}
+                    {typeof csvReport.synced === "number" && (
+                        <div className="text-muted">Synced records: {csvReport.synced}</div>
+                    )}
+                    {Array.isArray(csvReport.changeLog) && csvReport.changeLog.length > 0 && (
+                        <details>
+                            <summary>Change log</summary>
+                            <ul>
+                                {csvReport.changeLog.slice(0, 20).map((entry, idx) => (
+                                    <li key={idx}>
+                                        {entry.who || "row"}: {entry.note || (entry.changes || []).join(", ")}
+                                    </li>
+                                ))}
+                            </ul>
+                        </details>
+                    )}
+                </div>
+            )}
+        </div>
+    );
+}
+
+function MasterBotSettingsPanel() {
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState("");
+    const [settings, setSettings] = useState(null);
+    const [draft, setDraft] = useState(null);
+
+    const load = useCallback(async () => {
+        setLoading(true);
+        setError("");
+        try {
+            const value = await ServerAdmin.masterBot.get();
+            setSettings(value);
+            setDraft(value);
+        } catch (err) {
+            setError(formatError(err));
+        } finally {
+            setLoading(false);
+        }
+    }, []);
+
+    useEffect(() => {
+        load();
+    }, [load]);
+
+    const handleChange = (changes) => {
+        setDraft((prev) => ({ ...(prev || {}), ...changes }));
+    };
+
+    const handleArrayChange = (key, value) => {
+        handleChange({ [key]: value.split(",").map((item) => item.trim()).filter(Boolean) });
+    };
+
+    const handleNestedChange = (group, key, value) => {
+        setDraft((prev) => ({
+            ...(prev || {}),
+            [group]: { ...(prev?.[group] || {}), [key]: value },
+        }));
+    };
+
+    const handleToggle = (group, key, checked) => {
+        setDraft((prev) => ({
+            ...(prev || {}),
+            [group]: { ...(prev?.[group] || {}), [key]: checked },
+        }));
+    };
+
+    const handleSave = async () => {
+        try {
+            const saved = await ServerAdmin.masterBot.update(draft || {});
+            setSettings(saved);
+            setDraft(saved);
+            alert("Settings updated");
+        } catch (err) {
+            alert(formatError(err));
+        }
+    };
+
+    if (loading && !settings) {
+        return <div className="text-muted">Loading settings…</div>;
+    }
+
+    if (error && !settings) {
+        return <div className="alert warn">{error}</div>;
+    }
+
+    return (
+        <div className="col" style={{ gap: 16 }}>
+            <div className="row" style={{ justifyContent: "space-between", alignItems: "center" }}>
+                <h2 style={{ margin: 0 }}>Master Discord Bot</h2>
+                <div className="row" style={{ gap: 8 }}>
+                    <button type="button" className="btn ghost" onClick={load} disabled={loading}>
+                        {loading ? "Loading…" : "Reset"}
+                    </button>
+                    <button type="button" className="btn" onClick={handleSave} disabled={loading}>
+                        Save Settings
+                    </button>
+                </div>
+            </div>
+            {error && <div className="alert warn">{error}</div>}
+            <div className="col" style={{ gap: 12 }}>
+                <label className="col">
+                    <span className="text-muted text-small">Command Prefix</span>
+                    <input
+                        value={draft?.prefix || ""}
+                        onChange={(e) => handleChange({ prefix: e.target.value })}
+                    />
+                </label>
+                <label className="col">
+                    <span className="text-muted text-small">Admin Roles (comma separated)</span>
+                    <textarea
+                        rows={2}
+                        value={(draft?.adminRoles || []).join(", ")}
+                        onChange={(e) => handleArrayChange("adminRoles", e.target.value)}
+                    />
+                </label>
+                <div className="grid" style={{ gap: 12, gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))" }}>
+                    {Object.entries(draft?.channelBindings || {}).map(([key, value]) => (
+                        <label key={key} className="col">
+                            <span className="text-muted text-small">Channel: {key}</span>
+                            <input
+                                value={value || ""}
+                                onChange={(e) => handleNestedChange("channelBindings", key, e.target.value)}
+                            />
+                        </label>
+                    ))}
+                </div>
+                <div className="grid" style={{ gap: 12, gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))" }}>
+                    {Object.entries(draft?.webhooks || {}).map(([key, value]) => (
+                        <label key={key} className="col">
+                            <span className="text-muted text-small">Webhook: {key}</span>
+                            <input
+                                value={value || ""}
+                                onChange={(e) => handleNestedChange("webhooks", key, e.target.value)}
+                            />
+                        </label>
+                    ))}
+                </div>
+                <div className="col" style={{ gap: 8 }}>
+                    <span className="text-muted text-small">Event Toggles</span>
+                    {Object.entries(draft?.events || {}).map(([key, value]) => (
+                        <label key={key} className="row" style={{ gap: 8, alignItems: "center" }}>
+                            <input
+                                type="checkbox"
+                                checked={!!value}
+                                onChange={(e) => handleToggle("events", key, e.target.checked)}
+                            />
+                            <span>{key}</span>
+                        </label>
+                    ))}
+                </div>
+            </div>
+        </div>
+    );
+}
+
+export default function ServerManagementTab({ activeGameId, onGameDeleted, onRefreshGames, onRefreshActiveGame }) {
+    const [subtab, setSubtab] = useState(SUBTABS[0].key);
+
+    const renderContent = () => {
+        switch (subtab) {
+            case "users":
+                return <UsersAdminPanel onChanged={onRefreshGames} />;
+            case "games":
+                return (
+                    <GamesAdminPanel
+                        activeGameId={activeGameId}
+                        onGameDeleted={onGameDeleted}
+                        onRefreshGames={onRefreshGames}
+                        onRefreshActiveGame={onRefreshActiveGame}
+                    />
+                );
+            case "demons":
+                return <DemonsAdminPanel />;
+            case "bot":
+                return <MasterBotSettingsPanel />;
+            default:
+                return null;
+        }
+    };
+
+    return (
+        <div className="col" style={{ gap: 20 }}>
+            <header className="row" style={{ gap: 8, flexWrap: "wrap" }}>
+                {SUBTABS.map((item) => (
+                    <button
+                        key={item.key}
+                        type="button"
+                        className={`btn ghost${subtab === item.key ? " is-active" : ""}`}
+                        onClick={() => setSubtab(item.key)}
+                    >
+                        {item.label}
+                    </button>
+                ))}
+            </header>
+            <section>{renderContent()}</section>
+        </div>
+    );
+}

--- a/scripts/update-demons.mjs
+++ b/scripts/update-demons.mjs
@@ -1,0 +1,172 @@
+#!/usr/bin/env node
+/* eslint-env node */
+
+import fs from 'fs/promises';
+import path from 'path';
+import readline from 'readline';
+import { fileURLToPath } from 'url';
+import { applyCsvFileToDemons, writeDemonsFile } from '../server/services/demonCsvImport.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+function usage(message) {
+    if (message) {
+        console.error(`Error: ${message}`);
+    }
+    console.log(`
+Usage:
+  node scripts/update-demons.mjs [--json <path>] [--csv <path>] [--out <path>]
+                                 [--dry-run] [--strict] [-y|--yes]
+
+Defaults:
+  --json ../server/data/demons.json
+  --csv  ./demon_import.csv
+  --out  same as --json
+`);
+    process.exit(message ? 1 : 0);
+}
+
+function parseArgs() {
+    const args = {
+        json: path.join(__dirname, '..', 'server', 'data', 'demons.json'),
+        csv: path.join(__dirname, 'demon_import.csv'),
+        out: null,
+        dryRun: false,
+        strict: false,
+        yes: false,
+    };
+
+    const argv = process.argv.slice(2);
+    for (let i = 0; i < argv.length; i += 1) {
+        const token = argv[i];
+        switch (token) {
+            case '--json':
+                args.json = argv[++i];
+                break;
+            case '--csv':
+                args.csv = argv[++i];
+                break;
+            case '--out':
+                args.out = argv[++i];
+                break;
+            case '--dry-run':
+                args.dryRun = true;
+                break;
+            case '--strict':
+                args.strict = true;
+                break;
+            case '-y':
+            case '--yes':
+                args.yes = true;
+                break;
+            case '--help':
+            case '-h':
+                usage();
+                break;
+            default:
+                usage(`Unknown argument: ${token}`);
+        }
+    }
+
+    if (!args.out) args.out = args.json;
+    return args;
+}
+
+async function confirmPrompt(message) {
+    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+    return new Promise((resolve) => {
+        rl.question(`${message} [y/N]: `, (answer) => {
+            rl.close();
+            const normalized = String(answer || '').trim().toLowerCase();
+            resolve(normalized === 'y' || normalized === 'yes');
+        });
+    });
+}
+
+function formatReport(result) {
+    const lines = [];
+    lines.push(`Rows processed: ${result.rowsProcessed}`);
+    lines.push(`Demons updated: ${result.demonsUpdated}`);
+    if (Array.isArray(result.warnings) && result.warnings.length > 0) {
+        lines.push('');
+        lines.push('Warnings:');
+        for (const warning of result.warnings) {
+            lines.push(` - ${warning}`);
+        }
+    }
+    lines.push('');
+    for (const entry of result.changeLog) {
+        const head = entry.who ? `→ ${entry.who}` : '→ (row)';
+        if (entry.note) {
+            lines.push(`${head}: ${entry.note}`);
+        } else if (entry.changes?.length) {
+            lines.push(`${head}:`);
+            for (const change of entry.changes) {
+                lines.push(`   ${change}`);
+            }
+        }
+    }
+    return lines.join('\n');
+}
+
+function timestamp() {
+    const now = new Date();
+    const pad = (value) => String(value).padStart(2, '0');
+    return `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}_${pad(now.getHours())}-${pad(
+        now.getMinutes(),
+    )}-${pad(now.getSeconds())}`;
+}
+
+(async () => {
+    const options = parseArgs();
+
+    try {
+        const csvExists = await fs
+            .access(options.csv)
+            .then(() => true)
+            .catch(() => false);
+        if (!csvExists) usage(`CSV file not found: ${options.csv}`);
+
+        const jsonExists = await fs
+            .access(options.json)
+            .then(() => true)
+            .catch(() => false);
+        if (!jsonExists) usage(`JSON file not found: ${options.json}`);
+
+        const result = await applyCsvFileToDemons({
+            csvPath: options.csv,
+            jsonPath: options.json,
+            strict: options.strict,
+        });
+
+        const report = formatReport(result);
+        if (options.dryRun) {
+            console.log('[DRY RUN] No files were written.\n');
+            console.log(report);
+            process.exit(0);
+        }
+
+        const outPath = options.out ? path.resolve(options.out) : path.resolve(options.json);
+        const jsonPath = path.resolve(options.json);
+
+        if (!options.yes && outPath === jsonPath) {
+            const proceed = await confirmPrompt(`About to overwrite ${jsonPath}. Backup will be created. Proceed?`);
+            if (!proceed) {
+                console.log('Aborted by user.');
+                process.exit(0);
+            }
+        }
+
+        const originalContent = await fs.readFile(jsonPath, 'utf8');
+        const backupPath = `${jsonPath}.${timestamp()}.bak`;
+        await fs.writeFile(backupPath, originalContent, 'utf8');
+        await writeDemonsFile(result.demons, outPath);
+
+        console.log(`Backup created: ${backupPath}`);
+        console.log(`Wrote updates to: ${outPath}\n`);
+        console.log(report);
+    } catch (err) {
+        console.error(err?.stack || err?.message || String(err));
+        process.exit(1);
+    }
+})();

--- a/server/models/ServerSetting.js
+++ b/server/models/ServerSetting.js
@@ -1,0 +1,14 @@
+import mongoose from '../lib/mongoose.js';
+
+const serverSettingSchema = new mongoose.Schema(
+    {
+        key: { type: String, required: true, unique: true, index: true },
+        value: { type: mongoose.Schema.Types.Mixed, default: {} },
+    },
+    {
+        timestamps: true,
+        minimize: false,
+    },
+);
+
+export default mongoose.models.ServerSetting || mongoose.model('ServerSetting', serverSettingSchema);

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -5,6 +5,14 @@ const userSchema = new mongoose.Schema(
         id: { type: String, required: true, unique: true, index: true },
         username: { type: String, required: true, unique: true, index: true },
         pass: { type: String, required: true },
+        email: {
+            type: String,
+            lowercase: true,
+            trim: true,
+            unique: true,
+            sparse: true,
+        },
+        banned: { type: Boolean, default: false },
     },
     {
         timestamps: true,

--- a/server/server.js
+++ b/server/server.js
@@ -19,12 +19,21 @@ import User from './models/User.js';
 import Game from './models/Game.js';
 import Demon from './models/Demon.js';
 import Item from './models/Item.js';
+import ServerSetting from './models/ServerSetting.js';
 import { loadDemonEntries } from './lib/demonImport.js';
 import { loadItemEntries, parseHealingEffect } from './lib/itemImport.js';
 import { DEFAULT_WORLD_SKILLS } from '../shared/worldSkills.js';
 import { findCombatSkillById, findCombatSkillByName } from '../shared/combatSkills.js';
 import { MUSIC_TRACKS, getMusicTrack } from '../shared/music/index.js';
 import { FUSE_ARCANA_KEY_BY_LABEL, FUSE_ARCANA_ORDER } from '../shared/fusionArcana.js';
+import {
+    DEMONS_JSON_PATH,
+    applyCsvToDemons,
+    loadDemonsFile,
+    replaceDemonInList,
+    updateDemonEntry,
+    writeDemonsFile,
+} from './services/demonCsvImport.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const PROJECT_ROOT = path.resolve(__dirname, '..');
@@ -42,6 +51,26 @@ const pendingTrades = new Map();
 const storyBroadcastQueue = new Map();
 const FUSION_OVERRIDE_RANDOM = 'none';
 const DISCORD_API_BASE = 'https://discord.com/api/v10';
+const SERVER_ADMIN_USERNAMES = new Set(['captainpax', 'amzyoshio']);
+const MASTER_DISCORD_SETTINGS_KEY = 'masterDiscordBot';
+const DEFAULT_MASTER_BOT_SETTINGS = Object.freeze({
+    prefix: '!',
+    adminRoles: [],
+    channelBindings: {
+        announcements: '',
+        logs: '',
+        commands: '',
+    },
+    webhooks: {
+        gameStart: '',
+        alerts: '',
+    },
+    events: {
+        sendGameStartMessage: true,
+        autoSyncUsers: false,
+        notifyDemonUpdate: false,
+    },
+});
 const readiness = {
     db: false,
     discord: false,
@@ -1833,6 +1862,61 @@ function ensurePlayerShape(player) {
     }
     out.gear = ensureGearState(out);
     return out;
+}
+
+function createPlayerEntry(user, role = 'player') {
+    if (!user || typeof user !== 'object') return null;
+    const entry = {
+        userId: user.id,
+        username: user.username,
+        role,
+        character: null,
+        inventory: [],
+        gear: { bag: [], slots: { weapon: null, armor: null, accessory: null } },
+    };
+    return ensurePlayerShape(entry);
+}
+
+function assignGameDungeonMaster(game, userOrId, { users = [] } = {}) {
+    if (!game || typeof game !== 'object') return;
+    const targetId = typeof userOrId === 'string' ? userOrId : userOrId?.id;
+    const players = Array.isArray(game.players) ? [...game.players] : [];
+
+    if (!targetId) {
+        game.dmId = null;
+        game.players = players.map((player) => {
+            if (!player || typeof player !== 'object') return player;
+            if ((player.role || '').toLowerCase() === 'dm') {
+                return { ...player, role: 'player' };
+            }
+            return player;
+        });
+        return;
+    }
+
+    let dmEntry = players.find((player) => player && player.userId === targetId) || null;
+    if (!dmEntry) {
+        const user = Array.isArray(users) ? users.find((u) => u && u.id === targetId) : null;
+        const created = createPlayerEntry(user || { id: targetId, username: '' }, 'dm');
+        if (created) {
+            players.push(created);
+            dmEntry = created;
+        }
+    }
+
+    const updatedPlayers = players.map((player) => {
+        if (!player || typeof player !== 'object') return player;
+        if (player.userId === targetId) {
+            return { ...player, role: 'dm' };
+        }
+        if ((player.role || '').toLowerCase() === 'dm') {
+            return { ...player, role: 'player' };
+        }
+        return player;
+    });
+
+    game.dmId = targetId;
+    game.players = updatedPlayers;
 }
 
 function getGame(db, id) {
@@ -3774,6 +3858,7 @@ function ensureStoryConfig(game) {
     return normalized;
 }
 
+const EMAIL_REGEX = /^[^@\s]+@[^@\s]+\.[^@\s]+$/;
 const USERNAME_REGEX = /^[A-Za-z0-9_]{3,30}$/;
 const INVALID_GAME_NAME_CHARS = /[<>\n\r\t]/;
 const INVITE_CODE_REGEX = /^[A-Z0-9]{6}$/;
@@ -3791,6 +3876,14 @@ function readPassword(value) {
     const password = value;
     if (password.length < 8 || password.length > 128) return null;
     return password;
+}
+
+function readEmail(value) {
+    if (typeof value !== 'string') return null;
+    const email = value.trim().toLowerCase();
+    if (!email || email.length > 254) return null;
+    if (!EMAIL_REGEX.test(email)) return null;
+    return email;
 }
 
 function readGameName(value) {
@@ -3921,6 +4014,26 @@ async function ensureInitialDemonDocs() {
     }
 }
 
+async function syncDemonsToDatabase() {
+    const entries = await loadDemonEntries();
+    if (!Array.isArray(entries) || entries.length === 0) {
+        throw new Error('No demons found in data/demons.json');
+    }
+
+    const bulkOps = entries.map((entry) => ({
+        replaceOne: {
+            filter: { slug: entry.slug },
+            replacement: entry,
+            upsert: true,
+        },
+    }));
+
+    await Demon.bulkWrite(bulkOps, { ordered: false });
+    const keepSlugs = entries.map((entry) => entry.slug);
+    await Demon.deleteMany({ slug: { $nin: keepSlugs } });
+    return entries.length;
+}
+
 async function readDB() {
     const [users, games] = await Promise.all([
         User.find().lean(),
@@ -3973,6 +4086,120 @@ function hash(pw, salt) {
     return crypto.createHash('sha256').update(salt + pw).digest('hex');
 }
 
+function isServerAdminUser(user) {
+    if (!user || typeof user.username !== 'string') return false;
+    return SERVER_ADMIN_USERNAMES.has(user.username.toLowerCase());
+}
+
+function sanitizeUserRecord(user) {
+    if (!user || typeof user !== 'object') return user;
+    const { pass: _pass, ...rest } = user;
+    return rest;
+}
+
+async function getUserById(id) {
+    if (!id) return null;
+    return User.findOne({ id }).lean();
+}
+
+async function requireServerAdmin(req, res, next) {
+    if (!req.session?.userId) {
+        return res.status(401).json({ error: 'unauthenticated' });
+    }
+
+    const user = await getUserById(req.session.userId);
+    if (!user) {
+        return res.status(401).json({ error: 'unauthenticated' });
+    }
+    if (user.banned) {
+        return res.status(403).json({ error: 'forbidden' });
+    }
+    if (!isServerAdminUser(user)) {
+        return res.status(403).json({ error: 'forbidden' });
+    }
+
+    req.adminUser = sanitizeUserRecord(user);
+    return next();
+}
+
+function timestampLabel() {
+    const now = new Date();
+    const pad = (value) => String(value).padStart(2, '0');
+    return `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}_${pad(now.getHours())}-${pad(
+        now.getMinutes(),
+    )}-${pad(now.getSeconds())}`;
+}
+
+async function backupDemonsFile() {
+    const raw = await fs.readFile(DEMONS_JSON_PATH, 'utf8');
+    const backupPath = `${DEMONS_JSON_PATH}.${timestampLabel()}.bak`;
+    await fs.writeFile(backupPath, raw, 'utf8');
+    return backupPath;
+}
+
+function normalizeStringList(list) {
+    if (!Array.isArray(list)) return [];
+    const seen = new Set();
+    const output = [];
+    for (const value of list) {
+        if (typeof value !== 'string') continue;
+        const trimmed = value.trim();
+        if (!trimmed) continue;
+        const lower = trimmed.toLowerCase();
+        if (seen.has(lower)) continue;
+        seen.add(lower);
+        output.push(trimmed);
+    }
+    return output;
+}
+
+function normalizeStringMap(raw, template) {
+    const base = { ...template };
+    if (!raw || typeof raw !== 'object') return base;
+    for (const key of Object.keys(base)) {
+        const value = raw[key];
+        base[key] = typeof value === 'string' ? value.trim() : base[key];
+    }
+    return base;
+}
+
+function normalizeEventToggles(raw, template) {
+    const base = { ...template };
+    if (!raw || typeof raw !== 'object') return base;
+    for (const key of Object.keys(base)) {
+        base[key] = !!raw[key];
+    }
+    return base;
+}
+
+function normalizeMasterBotSettings(raw) {
+    const source = raw && typeof raw === 'object' ? raw : {};
+    const prefix = typeof source.prefix === 'string' && source.prefix.trim()
+        ? source.prefix.trim()
+        : DEFAULT_MASTER_BOT_SETTINGS.prefix;
+    const adminRoles = normalizeStringList(source.adminRoles ?? DEFAULT_MASTER_BOT_SETTINGS.adminRoles);
+    const channelBindings = normalizeStringMap(source.channelBindings, DEFAULT_MASTER_BOT_SETTINGS.channelBindings);
+    const webhooks = normalizeStringMap(source.webhooks, DEFAULT_MASTER_BOT_SETTINGS.webhooks);
+    const events = normalizeEventToggles(source.events, DEFAULT_MASTER_BOT_SETTINGS.events);
+    return { prefix, adminRoles, channelBindings, webhooks, events };
+}
+
+async function getMasterBotSettings() {
+    const doc = await ServerSetting.findOne({ key: MASTER_DISCORD_SETTINGS_KEY }).lean();
+    if (!doc) return { ...DEFAULT_MASTER_BOT_SETTINGS };
+    return normalizeMasterBotSettings(doc.value);
+}
+
+async function saveMasterBotSettings(settings) {
+    const normalized = normalizeMasterBotSettings(settings);
+    await ServerSetting.findOneAndUpdate(
+        { key: MASTER_DISCORD_SETTINGS_KEY },
+        { value: normalized },
+        { upsert: true, setDefaultsOnInsert: true },
+    );
+    return normalized;
+}
+
 const app = express();
 
 const resolvedTrustProxy = (() => {
@@ -4004,7 +4231,7 @@ app.use(cors({
     credentials: true,
 }));
 
-app.use(express.json());
+app.use(express.json({ limit: '5mb' }));
 
 // if you ever run behind a proxy/https later
 // app.set('trust proxy', 1);
@@ -4085,27 +4312,56 @@ function requireAuth(req, res, next) {
 app.get('/api/auth/me', async (req, res) => {
     const db = await readDB();
     const user = db.users.find(u => u.id === req.session.userId);
-    res.json(user ? { id: user.id, username: user.username } : null);
+    if (!user) {
+        res.json(null);
+        return;
+    }
+    const sanitized = sanitizeUserRecord(user);
+    res.json({
+        id: sanitized.id,
+        username: sanitized.username,
+        email: sanitized.email || null,
+        banned: !!sanitized.banned,
+        isAdmin: isServerAdminUser(sanitized),
+    });
 });
 
 app.post('/api/auth/register', async (req, res) => {
     const username = readUsername(req.body?.username);
     const password = readPassword(req.body?.password);
-    if (!username || !password) return res.status(400).json({ error: 'invalid fields' });
+    const confirmPassword = readPassword(req.body?.confirmPassword);
+    const email = readEmail(req.body?.email);
+    if (!username || !password || !confirmPassword || !email) {
+        return res.status(400).json({ error: 'invalid_fields' });
+    }
+    if (password !== confirmPassword) {
+        return res.status(400).json({ error: 'password_mismatch' });
+    }
 
     const db = await readDB();
-    const exists = db.users.some((u) =>
-        typeof u?.username === 'string' && u.username.toLowerCase() === username.toLowerCase()
+    const exists = db.users.some(
+        (u) => typeof u?.username === 'string' && u.username.toLowerCase() === username.toLowerCase(),
     );
-    if (exists) return res.status(400).json({ error: 'user exists' });
+    if (exists) return res.status(409).json({ error: 'user_exists' });
+
+    const emailExists = db.users.some(
+        (u) => typeof u?.email === 'string' && u.email.toLowerCase() === email.toLowerCase(),
+    );
+    if (emailExists) return res.status(409).json({ error: 'email_exists' });
 
     const salt = crypto.randomBytes(8).toString('hex');
-    const user = { id: uuid(), username, pass: `${salt}$${hash(password, salt)}` };
+    const user = {
+        id: uuid(),
+        username,
+        email,
+        banned: false,
+        pass: `${salt}$${hash(password, salt)}`,
+    };
     db.users.push(user);
     await writeDB(db);
 
     req.session.userId = user.id;
-    res.json({ id: user.id, username: user.username });
+    res.json({ id: user.id, username: user.username, email: user.email, isAdmin: isServerAdminUser(user) });
 });
 
 app.post('/api/auth/login', async (req, res) => {
@@ -4119,17 +4375,280 @@ app.post('/api/auth/login', async (req, res) => {
     );
     if (!user) return res.status(400).json({ error: 'invalid credentials' });
 
+    if (user.banned) {
+        return res.status(403).json({ error: 'user_banned' });
+    }
+
     const [salt, stored] = user.pass.split('$');
     if (!salt || !stored || hash(password, salt) !== stored) {
         return res.status(400).json({ error: 'invalid credentials' });
     }
 
     req.session.userId = user.id;
-    res.json({ id: user.id, username: user.username });
+    res.json({
+        id: user.id,
+        username: user.username,
+        email: user.email || null,
+        isAdmin: isServerAdminUser(user),
+    });
 });
 
 app.post('/api/auth/logout', (req, res) => {
     req.session.destroy(() => res.json({ ok: true }));
+});
+
+// --- Admin ---
+app.get('/api/admin/users', requireServerAdmin, async (_req, res) => {
+    const db = await readDB();
+    res.json(db.users.map((user) => sanitizeUserRecord(user)));
+});
+
+app.patch('/api/admin/users/:id', requireServerAdmin, async (req, res) => {
+    const userId = parseUUID(req.params?.id);
+    if (!userId) return res.status(400).json({ error: 'invalid_user' });
+
+    const db = await readDB();
+    const target = db.users.find((u) => u && u.id === userId);
+    if (!target) return res.status(404).json({ error: 'not_found' });
+
+    if (Object.prototype.hasOwnProperty.call(req.body || {}, 'username')) {
+        const nextUsername = readUsername(req.body.username);
+        if (!nextUsername) return res.status(400).json({ error: 'invalid_username' });
+        const exists = db.users.some(
+            (u) =>
+                u &&
+                u.id !== userId &&
+                typeof u.username === 'string' &&
+                u.username.toLowerCase() === nextUsername.toLowerCase(),
+        );
+        if (exists) return res.status(409).json({ error: 'user_exists' });
+        target.username = nextUsername;
+    }
+
+    if (Object.prototype.hasOwnProperty.call(req.body || {}, 'email')) {
+        const rawEmail = req.body.email;
+        if (rawEmail === null || rawEmail === '' || rawEmail === undefined) {
+            delete target.email;
+        } else {
+            const nextEmail = readEmail(rawEmail);
+            if (!nextEmail) return res.status(400).json({ error: 'invalid_email' });
+            const exists = db.users.some(
+                (u) =>
+                    u &&
+                    u.id !== userId &&
+                    typeof u.email === 'string' &&
+                    u.email.toLowerCase() === nextEmail.toLowerCase(),
+            );
+            if (exists) return res.status(409).json({ error: 'email_exists' });
+            target.email = nextEmail;
+        }
+    }
+
+    if (Object.prototype.hasOwnProperty.call(req.body || {}, 'banned')) {
+        target.banned = !!req.body.banned;
+    }
+
+    await writeDB(db);
+    res.json(sanitizeUserRecord(target));
+});
+
+app.delete('/api/admin/users/:id', requireServerAdmin, async (req, res) => {
+    const userId = parseUUID(req.params?.id);
+    if (!userId) return res.status(400).json({ error: 'invalid_user' });
+
+    const db = await readDB();
+    const beforeLength = db.users.length;
+    db.users = db.users.filter((u) => u && u.id !== userId);
+    if (db.users.length === beforeLength) {
+        return res.status(404).json({ error: 'not_found' });
+    }
+
+    const modifiedGames = [];
+    db.games = (db.games || []).map((game) => {
+        if (!game || !game.id) return game;
+        let changed = false;
+        const originalPlayers = Array.isArray(game.players) ? game.players : [];
+        const nextPlayers = originalPlayers.filter((player) => player && player.userId !== userId);
+        if (nextPlayers.length !== originalPlayers.length) {
+            game.players = nextPlayers;
+            changed = true;
+        }
+
+        if (game.dmId === userId) {
+            const fallback = nextPlayers.find((player) => player && player.userId);
+            if (fallback) {
+                assignGameDungeonMaster(game, fallback.userId, { users: db.users });
+            } else {
+                assignGameDungeonMaster(game, null, { users: db.users });
+            }
+            changed = true;
+        }
+
+        if (changed) modifiedGames.push(game.id);
+        return game;
+    });
+
+    await writeDB(db);
+    for (const gameId of modifiedGames) {
+        broadcastGameUpdate(gameId, { reason: 'admin:userDelete', actorId: req.session.userId });
+    }
+    res.json({ ok: true });
+});
+
+app.get('/api/admin/games', requireServerAdmin, async (_req, res) => {
+    const db = await readDB();
+    const userMap = new Map((db.users || []).map((user) => [user.id, user]));
+    const games = (db.games || []).map((game) => ({
+        id: game.id,
+        name: game.name,
+        dmId: game.dmId,
+        dmUsername: userMap.get(game.dmId)?.username || null,
+        updatedAt: game.updatedAt || null,
+        createdAt: game.createdAt || null,
+        players: Array.isArray(game.players)
+            ? game.players.map((player) => ({
+                  userId: player.userId,
+                  role: player.role,
+                  username:
+                      userMap.get(player.userId)?.username ||
+                      (typeof player.username === 'string' ? player.username : null),
+              }))
+            : [],
+    }));
+    res.json(games);
+});
+
+app.delete('/api/admin/games/:id', requireServerAdmin, async (req, res) => {
+    const gameId = parseUUID(req.params?.id);
+    if (!gameId) return res.status(400).json({ error: 'invalid_game' });
+
+    const db = await readDB();
+    const game = getGame(db, gameId);
+    if (!game) return res.status(404).json({ error: 'not_found' });
+
+    removeStoryWatcher(gameId);
+    db.games = (db.games || []).filter((g) => g && g.id !== gameId);
+    await writeDB(db);
+    broadcastGameDeleted(gameId);
+    res.json({ ok: true });
+});
+
+app.delete('/api/admin/games/:id/players/:playerId', requireServerAdmin, async (req, res) => {
+    const gameId = parseUUID(req.params?.id);
+    const playerId = parseUUID(req.params?.playerId);
+    if (!gameId || !playerId) return res.status(400).json({ error: 'invalid_request' });
+
+    const db = await readDB();
+    const game = getGame(db, gameId);
+    if (!game) return res.status(404).json({ error: 'not_found' });
+    if (game.dmId === playerId) {
+        return res.status(400).json({ error: 'cannot_remove_dm' });
+    }
+
+    const players = Array.isArray(game.players) ? game.players : [];
+    if (!players.some((player) => player && player.userId === playerId)) {
+        return res.status(404).json({ error: 'player_not_found' });
+    }
+
+    game.players = players.filter((player) => player && player.userId !== playerId);
+    await persistGame(db, game, { reason: 'admin:removePlayer', actorId: req.session.userId });
+    res.json({ ok: true, players: game.players });
+});
+
+app.patch('/api/admin/games/:id', requireServerAdmin, async (req, res) => {
+    const gameId = parseUUID(req.params?.id);
+    if (!gameId) return res.status(400).json({ error: 'invalid_game' });
+
+    const dmIdRaw = req.body?.dmId;
+    const dmId = typeof dmIdRaw === 'string' ? parseUUID(dmIdRaw) : null;
+    if (!dmId) return res.status(400).json({ error: 'invalid_dm' });
+
+    const db = await readDB();
+    const game = getGame(db, gameId);
+    if (!game) return res.status(404).json({ error: 'not_found' });
+
+    const targetUser = db.users.find((user) => user && user.id === dmId);
+    if (!targetUser) return res.status(404).json({ error: 'user_not_found' });
+
+    assignGameDungeonMaster(game, targetUser, { users: db.users });
+    await persistGame(db, game, { reason: 'admin:setDm', actorId: req.session.userId });
+    res.json({ ok: true, dmId: game.dmId });
+});
+
+app.get('/api/admin/demons', requireServerAdmin, async (_req, res) => {
+    const demons = await loadDemonsFile();
+    res.json(demons);
+});
+
+app.patch('/api/admin/demons/:id', requireServerAdmin, async (req, res) => {
+    const idNum = Number(req.params?.id);
+    if (!Number.isFinite(idNum)) return res.status(400).json({ error: 'invalid_demon' });
+
+    const demons = await loadDemonsFile();
+    const current = demons.find((entry) => Number(entry?.id) === idNum);
+    if (!current) return res.status(404).json({ error: 'not_found' });
+
+    const updatedEntry = updateDemonEntry(current, req.body || {});
+    const { demons: nextDemons, updated } = replaceDemonInList(demons, idNum, updatedEntry);
+    if (!updated) return res.status(404).json({ error: 'not_found' });
+
+    await backupDemonsFile();
+    await writeDemonsFile(nextDemons);
+    res.json(updated);
+});
+
+app.post('/api/admin/demons/upload', requireServerAdmin, async (req, res) => {
+    const csvContent = typeof req.body?.csv === 'string' ? req.body.csv : null;
+    if (!csvContent || !csvContent.trim()) {
+        return res.status(400).json({ error: 'invalid_csv' });
+    }
+
+    const demons = await loadDemonsFile();
+    const result = applyCsvToDemons({ csvContent, demons });
+    if (result.demonsUpdated === 0) {
+        return res.json({
+            ok: true,
+            wrote: false,
+            rowsProcessed: result.rowsProcessed,
+            demonsUpdated: 0,
+            changeLog: result.changeLog,
+            mode: result.mode,
+            warnings: result.warnings,
+        });
+    }
+
+    const backupPath = await backupDemonsFile();
+    await writeDemonsFile(result.demons);
+    res.json({
+        ok: true,
+        wrote: true,
+        backupPath,
+        rowsProcessed: result.rowsProcessed,
+        demonsUpdated: result.demonsUpdated,
+        changeLog: result.changeLog,
+        mode: result.mode,
+        warnings: result.warnings,
+    });
+});
+
+app.post('/api/admin/demons/sync', requireServerAdmin, async (_req, res) => {
+    try {
+        const count = await syncDemonsToDatabase();
+        res.json({ ok: true, count });
+    } catch (err) {
+        console.warn('[admin] Failed to sync demon codex', err);
+        res.status(500).json({ error: 'sync_failed' });
+    }
+});
+
+app.get('/api/admin/master-bot', requireServerAdmin, async (_req, res) => {
+    const settings = await getMasterBotSettings();
+    res.json(settings);
+});
+
+app.put('/api/admin/master-bot', requireServerAdmin, async (req, res) => {
+    const saved = await saveMasterBotSettings(req.body || {});
+    res.json(saved);
 });
 
 // --- Games ---

--- a/server/services/demonCsvImport.js
+++ b/server/services/demonCsvImport.js
@@ -1,0 +1,614 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+export const DEMONS_JSON_PATH = path.join(__dirname, '..', 'data', 'demons.json');
+
+function splitCSV(line) {
+    const out = [];
+    let cur = '';
+    let inQuotes = false;
+    for (let i = 0; i < line.length; i += 1) {
+        const ch = line[i];
+        if (ch === '"') {
+            if (inQuotes && line[i + 1] === '"') {
+                cur += '"';
+                i += 1;
+            } else {
+                inQuotes = !inQuotes;
+            }
+        } else if (ch === ',' && !inQuotes) {
+            out.push(cur);
+            cur = '';
+        } else {
+            cur += ch;
+        }
+    }
+    out.push(cur);
+    return out;
+}
+
+function toLines(csvContent) {
+    if (typeof csvContent !== 'string') return [];
+    return csvContent
+        .replace(/\r\n/g, '\n')
+        .replace(/\r/g, '\n')
+        .split('\n');
+}
+
+function parseHeaderCSV(lines) {
+    let headers = null;
+    const rows = [];
+    for (const raw of lines) {
+        const trimmed = raw.trimEnd();
+        if (!trimmed) continue;
+        const cells = splitCSV(trimmed).map((cell) => cell.trim());
+        if (!headers) {
+            headers = cells;
+            continue;
+        }
+        const row = {};
+        headers.forEach((h, idx) => {
+            row[h] = cells[idx] ?? '';
+        });
+        rows.push(row);
+    }
+    return { mode: 'header', headers: headers ?? [], rows };
+}
+
+function parseCompendiumSheet(lines) {
+    const rows = [];
+    const sectionHeaderRe = /^\s*([0-9IVXLCDM]+)\.\s*([A-Za-z][\w\s\-']*)/i;
+    let currentArcana = null;
+
+    for (const raw of lines) {
+        const trimmed = raw.trimEnd();
+        if (!trimmed) continue;
+        const cells = splitCSV(trimmed).map((cell) => cell.trim());
+
+        const headerMatch = cells[0]?.match(sectionHeaderRe);
+        if (headerMatch) {
+            currentArcana = headerMatch[2].trim();
+            continue;
+        }
+
+        if (cells.every((cell) => cell === '')) continue;
+
+        const name = (cells[0] || '').trim();
+        if (!name) continue;
+
+        const levelStr = (cells[1] || '').trim();
+        const level = levelStr ? Number(levelStr) : null;
+        const skillsRaw = (cells[2] || '').trim();
+        const resistRaw = cells.find((cell) =>
+            /Weak\s*:|Resist\s*:|Null\s*:|Drain\s*:|Absorb\s*:|Repel\s*:|Reflect\s*:/i.test(cell),
+        ) || '';
+
+        rows.push({
+            name,
+            arcana: currentArcana || null,
+            level: Number.isFinite(level) ? level : null,
+            skillsRaw,
+            resistRaw,
+        });
+    }
+
+    return { mode: 'compendium', rows };
+}
+
+function parseFlexibleCsv(csvContent) {
+    const lines = toLines(csvContent);
+    const headerParsed = parseHeaderCSV(lines);
+    const hasNameOrId = headerParsed.headers.some((h) => /^(name|id)$/i.test(h));
+    if (hasNameOrId) return headerParsed;
+    return parseCompendiumSheet(lines);
+}
+
+function isObject(value) {
+    return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function cloneDeep(value) {
+    if (Array.isArray(value)) return value.map(cloneDeep);
+    if (isObject(value)) {
+        const out = {};
+        for (const key of Object.keys(value)) {
+            out[key] = cloneDeep(value[key]);
+        }
+        return out;
+    }
+    return value;
+}
+
+function deepEqual(a, b) {
+    if (a === b) return true;
+    if (Array.isArray(a) && Array.isArray(b)) {
+        if (a.length !== b.length) return false;
+        for (let i = 0; i < a.length; i += 1) {
+            if (!deepEqual(a[i], b[i])) return false;
+        }
+        return true;
+    }
+    if (isObject(a) && isObject(b)) {
+        const aKeys = Object.keys(a);
+        const bKeys = Object.keys(b);
+        if (aKeys.length !== bKeys.length) return false;
+        for (const key of aKeys) {
+            if (!deepEqual(a[key], b[key])) return false;
+        }
+        return true;
+    }
+    return false;
+}
+
+function typeKey(value) {
+    if (Array.isArray(value)) return 'array';
+    if (value === null) return 'null';
+    return typeof value;
+}
+
+function coerceToType(targetSample, incoming) {
+    if (targetSample === undefined) return incoming;
+    const targetType = Array.isArray(targetSample) ? 'array' : typeof targetSample;
+    if (targetSample === null) {
+        return String(incoming).trim().toLowerCase() === 'null' ? null : targetSample;
+    }
+
+    try {
+        switch (targetType) {
+            case 'number': {
+                if (typeof incoming === 'number') return incoming;
+                const num = Number(String(incoming).trim());
+                return Number.isFinite(num) ? num : targetSample;
+            }
+            case 'boolean': {
+                if (typeof incoming === 'boolean') return incoming;
+                const normalized = String(incoming).trim().toLowerCase();
+                if (['true', '1', 'yes', 'y'].includes(normalized)) return true;
+                if (['false', '0', 'no', 'n'].includes(normalized)) return false;
+                return targetSample;
+            }
+            case 'string':
+                return String(incoming);
+            case 'array': {
+                if (Array.isArray(incoming)) return incoming;
+                const serialized = String(incoming).trim();
+                if (!serialized) return targetSample;
+                if (serialized.startsWith('[') && serialized.endsWith(']')) {
+                    try {
+                        const parsed = JSON.parse(serialized);
+                        return Array.isArray(parsed) ? parsed : targetSample;
+                    } catch {
+                        return targetSample;
+                    }
+                }
+                const parts = serialized.split(/\s*[|;]\s*/).filter(Boolean);
+                return parts.length ? parts : targetSample;
+            }
+            case 'object': {
+                if (isObject(incoming)) return incoming;
+                const serialized = String(incoming).trim();
+                if (serialized.startsWith('{') && serialized.endsWith('}')) {
+                    try {
+                        const parsed = JSON.parse(serialized);
+                        return isObject(parsed) ? parsed : targetSample;
+                    } catch {
+                        return targetSample;
+                    }
+                }
+                return targetSample;
+            }
+            default:
+                return incoming;
+        }
+    } catch {
+        return targetSample;
+    }
+}
+
+function resolveKeyCI(obj, segment) {
+    if (!obj || typeof obj !== 'object') return null;
+    if (Object.prototype.hasOwnProperty.call(obj, segment)) return segment;
+    const lower = segment.toLowerCase();
+    for (const key of Object.keys(obj)) {
+        if (key.toLowerCase() === lower) return key;
+    }
+    return null;
+}
+
+function setByPath(schemaRoot, targetRoot, pathStr, newValue, { strict = false } = {}) {
+    const segments = pathStr.split('.');
+    let schemaCursor = schemaRoot;
+    let targetCursor = targetRoot;
+
+    for (let i = 0; i < segments.length; i += 1) {
+        const desired = segments[i];
+        const resolved = resolveKeyCI(schemaCursor ?? {}, desired);
+        const key = resolved ?? desired;
+        const last = i === segments.length - 1;
+
+        if (strict && (schemaCursor == null || !(key in schemaCursor))) {
+            return { changed: false, reason: `Skipped (strict): "${pathStr}" not in schema` };
+        }
+        if (!strict && i === 0 && !Object.prototype.hasOwnProperty.call(schemaCursor ?? {}, key)) {
+            return { changed: false, reason: `Skipped: top-level "${desired}" not in schema` };
+        }
+
+        if (!(key in targetCursor)) {
+            if (schemaCursor && key in schemaCursor) {
+                targetCursor[key] = Array.isArray(schemaCursor[key])
+                    ? []
+                    : isObject(schemaCursor[key])
+                    ? {}
+                    : schemaCursor[key];
+            } else {
+                return { changed: false, reason: `Skipped: "${pathStr}" missing in target` };
+            }
+        }
+
+        if (last) {
+            const before = targetCursor[key];
+            const after = coerceToType(schemaCursor ? schemaCursor[key] : undefined, newValue);
+            if (!deepEqual(before, after)) {
+                if (typeKey(before) !== typeKey(after)) {
+                    return {
+                        changed: false,
+                        reason: `Skipped: type mismatch on "${pathStr}" (${typeKey(before)} -> ${typeKey(after)})`,
+                    };
+                }
+                targetCursor[key] = after;
+                return { changed: true };
+            }
+            return { changed: false, reason: `Unchanged: "${pathStr}"` };
+        }
+
+        schemaCursor = schemaCursor ? schemaCursor[key] : undefined;
+        targetCursor = targetCursor[key];
+        if (!isObject(targetCursor) && !Array.isArray(targetCursor)) {
+            return {
+                changed: false,
+                reason: `Skipped: "${segments.slice(0, i + 1).join('.')}" not an object/array`,
+            };
+        }
+    }
+
+    return { changed: false, reason: 'Skipped: unknown' };
+}
+
+function parseSkills(skillsRaw) {
+    if (!skillsRaw) return null;
+    const parts = skillsRaw
+        .split('|')
+        .flatMap((chunk) => chunk.split(','))
+        .map((part) => part.trim())
+        .filter(Boolean);
+    return parts.length ? parts : null;
+}
+
+function parseResistances(resistRaw) {
+    if (!resistRaw) return null;
+    const clauses = resistRaw.split('|').map((part) => part.trim()).filter(Boolean);
+    const out = { weak: [], resist: [], block: [], drain: [], reflect: [] };
+
+    for (const clause of clauses) {
+        const match = clause.match(/^([A-Za-z ]+)\s*:\s*(.+)$/);
+        if (!match) continue;
+        const label = match[1].trim().toLowerCase();
+        const values = match[2]
+            .split(',')
+            .map((value) => value.trim())
+            .filter(Boolean);
+
+        let bucket = null;
+        if (label.startsWith('weak')) bucket = 'weak';
+        else if (label.startsWith('resist')) bucket = 'resist';
+        else if (label.startsWith('null') || label.startsWith('block')) bucket = 'block';
+        else if (label.startsWith('drain') || label.startsWith('absorb')) bucket = 'drain';
+        else if (label.startsWith('repel') || label.startsWith('reflect')) bucket = 'reflect';
+
+        if (!bucket) continue;
+        for (const value of values) {
+            if (!out[bucket].includes(value)) out[bucket].push(value);
+        }
+    }
+
+    const total = out.weak.length + out.resist.length + out.block.length + out.drain.length + out.reflect.length;
+    return total ? out : null;
+}
+
+function normalizeDemonsInput(demons) {
+    if (!Array.isArray(demons)) {
+        throw new Error('demons dataset must be an array');
+    }
+    return demons.map((entry) => (entry && typeof entry === 'object' ? cloneDeep(entry) : entry));
+}
+
+function detectDuplicateNames(parsed) {
+    if (!parsed || !Array.isArray(parsed.rows) || parsed.rows.length === 0) return [];
+
+    const warnings = [];
+    const seen = new Map();
+
+    if (parsed.mode === 'header') {
+        const headers = Array.isArray(parsed.headers) ? parsed.headers : [];
+        const nameKey = headers.find((header) => header && header.toLowerCase() === 'name');
+        if (!nameKey) return warnings;
+        const arcanaKey = headers.find((header) => header && header.toLowerCase() === 'arcana');
+
+        for (const row of parsed.rows) {
+            const rawName = row?.[nameKey];
+            if (typeof rawName !== 'string') continue;
+            const name = rawName.trim();
+            if (!name) continue;
+            const key = name.toLowerCase();
+            const entry = seen.get(key) || { name, count: 0, arcanas: new Set() };
+            entry.count += 1;
+            if (arcanaKey) {
+                const rawArcana = row?.[arcanaKey];
+                if (typeof rawArcana === 'string' && rawArcana.trim()) {
+                    entry.arcanas.add(rawArcana.trim());
+                }
+            }
+            seen.set(key, entry);
+        }
+    } else {
+        for (const row of parsed.rows) {
+            const rawName = row?.name;
+            if (typeof rawName !== 'string') continue;
+            const name = rawName.trim();
+            if (!name) continue;
+            const key = name.toLowerCase();
+            const entry = seen.get(key) || { name, count: 0, arcanas: new Set() };
+            entry.count += 1;
+            if (typeof row.arcana === 'string' && row.arcana.trim()) {
+                entry.arcanas.add(row.arcana.trim());
+            }
+            seen.set(key, entry);
+        }
+    }
+
+    for (const entry of seen.values()) {
+        if (entry.count <= 1) continue;
+        const arcanas = Array.from(entry.arcanas);
+        if (arcanas.length > 1) {
+            warnings.push(`Duplicate demon "${entry.name}" appears across multiple Arcanas: ${arcanas.join(', ')}.`);
+        } else if (arcanas.length === 1) {
+            warnings.push(`Duplicate demon "${entry.name}" appears multiple times in Arcana ${arcanas[0]}.`);
+        } else {
+            warnings.push(`Duplicate demon "${entry.name}" appears multiple times in the CSV input.`);
+        }
+    }
+
+    return warnings;
+}
+
+export function applyCsvToDemons({ csvContent, demons, strict = false }) {
+    const dataset = normalizeDemonsInput(demons);
+    const parsed = parseFlexibleCsv(csvContent);
+    const warnings = detectDuplicateNames(parsed);
+    const mapByName = new Map();
+    const mapById = new Map();
+
+    for (const entry of dataset) {
+        if (entry && typeof entry === 'object') {
+            if (typeof entry.name === 'string') {
+                mapByName.set(entry.name.toLowerCase(), entry);
+            }
+            if (Number.isFinite(Number(entry.id))) {
+                mapById.set(Number(entry.id), entry);
+            }
+        }
+    }
+
+    const changeLog = [];
+    let touched = 0;
+
+    if (parsed.mode === 'header') {
+        const headersLower = (parsed.headers || []).map((header) => header.toLowerCase());
+        let key = headersLower.includes('id') ? 'id' : headersLower.includes('name') ? 'name' : null;
+        if (!key) {
+            throw new Error('CSV must contain "id" or "name" column.');
+        }
+
+        for (const row of parsed.rows) {
+            const matchValue = row[key] ?? row[key.toUpperCase()] ?? row[key.toLowerCase()];
+            if (matchValue == null || String(matchValue).trim() === '') {
+                changeLog.push({ who: null, note: `Skipped row: missing ${key}` });
+                continue;
+            }
+
+            const demon = key === 'id' ? mapById.get(Number(matchValue)) : mapByName.get(String(matchValue).toLowerCase());
+            if (!demon) {
+                changeLog.push({ who: matchValue, note: 'No match in demons.json' });
+                continue;
+            }
+
+            const schema = demon;
+            const target = demon;
+            const before = cloneDeep(demon);
+            const perRowChanges = [];
+
+            for (const [column, rawValue] of Object.entries(row)) {
+                if (column.toLowerCase() === key) continue;
+                if (rawValue == null || String(rawValue).trim() === '') continue;
+                const res = setByPath(schema, target, column.trim(), rawValue, { strict });
+                if (res.changed) perRowChanges.push(`✓ ${column.trim()}`);
+                else if (res.reason) perRowChanges.push(`- ${column.trim()} (${res.reason})`);
+            }
+
+            const changed = !deepEqual(before, target);
+            if (changed) touched += 1;
+            changeLog.push({
+                who: key === 'id' ? `id=${matchValue}` : `name="${matchValue}"`,
+                changes: perRowChanges,
+            });
+        }
+    } else {
+        for (const row of parsed.rows) {
+            const demon = mapByName.get(row.name.toLowerCase());
+            if (!demon) {
+                changeLog.push({ who: row.name, note: 'No match in demons.json' });
+                continue;
+            }
+
+            const schema = demon;
+            const target = demon;
+            const before = cloneDeep(demon);
+            const perRowChanges = [];
+
+            if (row.arcana) {
+                const res = setByPath(schema, target, 'arcana', row.arcana, { strict });
+                if (res.changed) perRowChanges.push('✓ arcana');
+                else if (res.reason) perRowChanges.push(`- arcana (${res.reason})`);
+            }
+
+            if (row.level != null) {
+                const res = setByPath(schema, target, 'level', row.level, { strict });
+                if (res.changed) perRowChanges.push('✓ level');
+                else if (res.reason) perRowChanges.push(`- level (${res.reason})`);
+            }
+
+            const skills = parseSkills(row.skillsRaw);
+            if (skills && Array.isArray(schema.skills)) {
+                const res = setByPath(schema, target, 'skills', skills, { strict });
+                if (res.changed) perRowChanges.push('✓ skills');
+                else if (res.reason) perRowChanges.push(`- skills (${res.reason})`);
+            }
+
+            const resistances = parseResistances(row.resistRaw);
+            if (resistances && isObject(schema.resistances)) {
+                for (const bucket of ['weak', 'resist', 'block', 'drain', 'reflect']) {
+                    if (Array.isArray(schema.resistances[bucket]) && Array.isArray(resistances[bucket])) {
+                        const res = setByPath(schema, target, `resistances.${bucket}`, resistances[bucket], { strict });
+                        if (res.changed) perRowChanges.push(`✓ resistances.${bucket}`);
+                        else if (res.reason) perRowChanges.push(`- resistances.${bucket} (${res.reason})`);
+                    }
+                }
+            }
+
+            const changed = !deepEqual(before, target);
+            if (changed) touched += 1;
+            changeLog.push({ who: `name="${row.name}"`, changes: perRowChanges });
+        }
+    }
+
+    return {
+        demons: dataset,
+        rowsProcessed: parsed.rows.length,
+        demonsUpdated: touched,
+        changeLog,
+        mode: parsed.mode,
+        warnings,
+    };
+}
+
+export async function loadDemonsFile(filePath = DEMONS_JSON_PATH) {
+    const raw = await fs.readFile(filePath, 'utf8');
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+        throw new Error('Expected demons.json to contain an array.');
+    }
+    return parsed;
+}
+
+export async function writeDemonsFile(demons, filePath = DEMONS_JSON_PATH) {
+    await fs.writeFile(filePath, `${JSON.stringify(demons, null, 2)}\n`, 'utf8');
+}
+
+export async function applyCsvFileToDemons({ csvPath, jsonPath = DEMONS_JSON_PATH, strict = false }) {
+    const [csvContent, demons] = await Promise.all([
+        fs.readFile(csvPath, 'utf8'),
+        loadDemonsFile(jsonPath),
+    ]);
+    const result = applyCsvToDemons({ csvContent, demons, strict });
+    return { ...result, demons: result.demons };
+}
+
+export function updateDemonEntry(entry, updates) {
+    if (!entry || typeof entry !== 'object') {
+        throw new Error('Invalid demon entry');
+    }
+    const allowedKeys = new Set([
+        'name',
+        'arcana',
+        'alignment',
+        'personality',
+        'strategy',
+        'level',
+        'description',
+        'image',
+        'query',
+        'skills',
+        'resistances',
+        'stats',
+        'mods',
+        'dlc',
+        'tags',
+    ]);
+
+    const next = cloneDeep(entry);
+    for (const [key, value] of Object.entries(updates || {})) {
+        if (!allowedKeys.has(key)) continue;
+        if (key === 'level') {
+            const num = Number(value);
+            next.level = Number.isFinite(num) ? num : next.level;
+            continue;
+        }
+        if (key === 'skills') {
+            next.skills = Array.isArray(value)
+                ? value.filter((item) => typeof item === 'string' && item.trim()).map((item) => item.trim())
+                : next.skills;
+            continue;
+        }
+        if (key === 'resistances') {
+            const payload = value && typeof value === 'object' ? value : {};
+            next.resistances = {
+                weak: Array.isArray(payload.weak) ? payload.weak.map((item) => String(item).trim()).filter(Boolean) : next.resistances?.weak ?? [],
+                resist: Array.isArray(payload.resist)
+                    ? payload.resist.map((item) => String(item).trim()).filter(Boolean)
+                    : next.resistances?.resist ?? [],
+                block: Array.isArray(payload.block)
+                    ? payload.block.map((item) => String(item).trim()).filter(Boolean)
+                    : next.resistances?.block ?? [],
+                drain: Array.isArray(payload.drain)
+                    ? payload.drain.map((item) => String(item).trim()).filter(Boolean)
+                    : next.resistances?.drain ?? [],
+                reflect: Array.isArray(payload.reflect)
+                    ? payload.reflect.map((item) => String(item).trim()).filter(Boolean)
+                    : next.resistances?.reflect ?? [],
+            };
+            continue;
+        }
+        if (key === 'stats' || key === 'mods') {
+            const source = value && typeof value === 'object' ? value : {};
+            const template = next[key] && typeof next[key] === 'object' ? next[key] : {};
+            const updated = { ...template };
+            for (const statKey of ['STR', 'DEX', 'CON', 'INT', 'WIS', 'CHA']) {
+                const raw = Number(source[statKey]);
+                if (Number.isFinite(raw)) {
+                    updated[statKey] = raw;
+                }
+            }
+            next[key] = updated;
+            continue;
+        }
+        if (key === 'tags') {
+            if (Array.isArray(value)) {
+                next.tags = value.map((tag) => String(tag).trim()).filter(Boolean);
+            }
+            continue;
+        }
+        next[key] = typeof value === 'string' ? value : value ?? next[key];
+    }
+    return next;
+}
+
+export function replaceDemonInList(demons, id, updated) {
+    const list = normalizeDemonsInput(demons);
+    const index = list.findIndex((entry) => Number(entry?.id) === Number(id));
+    if (index === -1) return { demons: list, updated: null };
+    const next = cloneDeep(list);
+    next[index] = updated;
+    return { demons: next, updated: next[index] };
+}


### PR DESCRIPTION
## Summary
- expose a server management tab in the client for CaptainPax and AMZYoshio with subtabs for users, games, demons, and master bot settings
- add admin REST endpoints on the server for managing users, games, demon imports, and master Discord defaults, including Mongo sync support
- introduce a reusable demon CSV import service and CLI along with new models to persist global bot configuration

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d997fc48b883319a3e21348c5003a3