### PR TITLE
Add LocalAI integrations for portrait generation and background updates

### DIFF
--- a/client/src/api.js
+++ b/client/src/api.js
@@ -834,6 +834,23 @@ export const StoryLogs = {
         }),
 };
 
+export const LocalAI = {
+    generatePortrait: (payload) =>
+        api('/api/ai/portrait', {
+            method: 'POST',
+            body: payload,
+            timeoutMs: 120_000,
+            noRetry: true,
+        }),
+    enhanceBackground: (payload) =>
+        api('/api/ai/background', {
+            method: 'POST',
+            body: payload,
+            timeoutMs: 120_000,
+            noRetry: true,
+        }),
+};
+
 // ---------------- Helper: SSE (Server-Sent Events) ----------------
 // If you later expose real-time updates from the server, you can wire them here.
 /*

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -3283,6 +3283,22 @@ label {
     margin: 0;
     font-size: 0.8rem;
 }
+.sheet-portrait__messages { display: grid; gap: 4px; }
+.sheet-portrait__prompt {
+    font-size: 0.85rem;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    padding: 8px 10px;
+    background: var(--surface);
+}
+.sheet-portrait__prompt summary {
+    cursor: pointer;
+    font-weight: 600;
+}
+.sheet-portrait__prompt p {
+    margin: 6px 0 0;
+    white-space: pre-wrap;
+}
 
 @media (max-width: 600px) {
     .sheet-portrait {
@@ -3327,8 +3343,33 @@ label {
 .sheet-grid { display: grid; gap: 12px; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); }
 .sheet-grid--stretch { grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); }
 .sheet-grid--resources { grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); }
+.ai-suggestion {
+    margin-top: 12px;
+    padding: 12px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    background: var(--surface);
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+.ai-suggestion__header h5 {
+    margin: 0;
+    font-size: 1rem;
+}
+.ai-suggestion__header p {
+    margin: 4px 0 0;
+}
+.ai-suggestion__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+}
 .field { display: flex; flex-direction: column; gap: 6px; font-size: 0.95rem; }
 .field__label { font-size: 0.7rem; font-weight: 600; letter-spacing: 0.06em; text-transform: uppercase; color: var(--muted); }
+.field__header { display: flex; align-items: center; justify-content: space-between; gap: 8px; flex-wrap: wrap; }
+.field--with-action { gap: 10px; }
+.field__error { margin: 0; font-size: 0.8rem; }
 .field input,
 .field select,
 .field textarea { font: inherit; }

--- a/server/routes/localai.routes.js
+++ b/server/routes/localai.routes.js
@@ -1,0 +1,38 @@
+import { Router } from 'express';
+import { generateCharacterImage, enhanceBackgroundAndNotes } from '../services/localAi.js';
+
+const router = Router();
+
+function normalizeCharacterPayload(value) {
+    if (!value || typeof value !== 'object') return {};
+    return value;
+}
+
+router.post('/portrait', async (req, res) => {
+    try {
+        const character = normalizeCharacterPayload(req.body?.character);
+        const overrides = req.body?.overrides && typeof req.body.overrides === 'object' ? req.body.overrides : {};
+        const result = await generateCharacterImage(character, overrides);
+        res.json(result);
+    } catch (err) {
+        console.error('Failed to generate portrait', err);
+        const status = err?.status || 502;
+        res.status(status).json({ error: err?.message || 'Image generation failed' });
+    }
+});
+
+router.post('/background', async (req, res) => {
+    try {
+        const character = normalizeCharacterPayload(req.body?.character);
+        const background = typeof req.body?.background === 'string' ? req.body.background : '';
+        const notes = typeof req.body?.notes === 'string' ? req.body.notes : '';
+        const result = await enhanceBackgroundAndNotes(character, background, notes);
+        res.json(result);
+    } catch (err) {
+        console.error('Failed to enhance background', err);
+        const status = err?.status || 502;
+        res.status(status).json({ error: err?.message || 'Background enhancement failed' });
+    }
+});
+
+export default router;

--- a/server/server.js
+++ b/server/server.js
@@ -13,6 +13,7 @@ import { fileURLToPath } from 'url';
 import cors from 'cors';
 
 import personas from './routes/personas.routes.js';
+import localAiRoutes from './routes/localai.routes.js';
 import { createDiscordWatcher } from './discordWatcher.js';
 import { loadEnv, envString, envNumber, envBoolean } from './config/env.js';
 import User from './models/User.js';
@@ -7116,6 +7117,7 @@ app.get('/api/help/docs', async (_req, res) => {
 });
 
 // Persona proxy routes
+app.use('/api/ai', localAiRoutes);
 app.use('/api/personas', personas);
 
 // Static files (if built)

--- a/server/services/localAi.js
+++ b/server/services/localAi.js
@@ -1,0 +1,318 @@
+import { PromptTemplate, ChatPromptTemplate } from "@langchain/core/prompts";
+import { RunnableSequence, RunnableLambda } from "@langchain/core/runnables";
+import { StringOutputParser } from "@langchain/core/output_parsers";
+
+const CHAT_ENDPOINT = "https://jack-ai.darkmatterservers.com/chat/all-hands_openhands-lm-7b-v0.1";
+const IMAGE_ENDPOINT = "https://jack-ai.darkmatterservers.com/text2image/dreamshaper";
+const DEFAULT_NEGATIVE_PROMPT =
+    "blurry, distorted, extra limbs, duplicate face, deformed, low quality, watermark, signature";
+
+const portraitTemplate = PromptTemplate.fromTemplate(
+    "Portrait of a {race} {role}, wearing {armor}, in a {setting} background, with {expression} expression."
+);
+
+const backgroundPrompt = ChatPromptTemplate.fromMessages([
+    [
+        "system",
+        "You are a creative tabletop RPG assistant. Use the provided character data to enhance their background and notes. " +
+            "Respond with valid JSON containing two keys: background and notes. Each value should be multi-paragraph prose that " +
+            "fits the tone of the original material, avoids contradicting established facts, and stays suitable for a teen-friendly campaign."
+    ],
+    [
+        "user",
+        "Help enhance this character's background and notes using the following data. " +
+            "Return only JSON.\n\nCharacter summary:\n{summary}\n\nCurrent background:\n{background}\n\nCurrent notes:\n{notes}"
+    ],
+]);
+
+const callChatEndpoint = new RunnableLambda({
+    func: async (messages) => {
+        const controller = new AbortController();
+        const timeout = setTimeout(() => controller.abort(), 60_000);
+        try {
+            const response = await fetch(CHAT_ENDPOINT, {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                },
+                signal: controller.signal,
+                body: JSON.stringify({
+                    messages,
+                    temperature: 0.8,
+                    max_tokens: 600,
+                    stream: false,
+                }),
+            });
+
+            if (!response.ok) {
+                const text = await response.text().catch(() => "");
+                throw new Error(`Chat model request failed (${response.status}): ${text || response.statusText}`);
+            }
+
+            const payload = await response.json();
+            const content =
+                payload?.choices?.[0]?.message?.content || payload?.message?.content || payload?.content || "";
+            if (!content) {
+                throw new Error("Chat model returned an empty response.");
+            }
+            return content;
+        } finally {
+            clearTimeout(timeout);
+        }
+    },
+});
+
+const parseJsonOutput = new RunnableLambda({
+    func: async (raw) => {
+        const text = typeof raw === "string" ? raw.trim() : "";
+        if (!text) {
+            throw new Error("Model response was empty.");
+        }
+        const candidate = extractJsonBlock(text);
+        try {
+            const parsed = JSON.parse(candidate);
+            const background = safeString(parsed.background);
+            const notes = safeString(parsed.notes);
+            if (!background && !notes) {
+                throw new Error("Model response did not include background or notes.");
+            }
+            return { background, notes };
+        } catch (err) {
+            throw new Error(`Failed to parse model response as JSON: ${err.message}`);
+        }
+    },
+});
+
+const backgroundChain = RunnableSequence.from([
+    backgroundPrompt,
+    callChatEndpoint,
+    new StringOutputParser(),
+    parseJsonOutput,
+]);
+
+function safeString(value) {
+    if (typeof value === "string") {
+        return value.trim();
+    }
+    if (Array.isArray(value)) {
+        return value.map((item) => safeString(item)).filter(Boolean).join("\n");
+    }
+    if (value && typeof value === "object") {
+        return Object.values(value)
+            .map((item) => safeString(item))
+            .filter(Boolean)
+            .join("\n");
+    }
+    return "";
+}
+
+function extractJsonBlock(text) {
+    const trimmed = text.trim();
+    const fenced = trimmed.match(/```json\s*([\s\S]+?)```/i);
+    if (fenced) {
+        return fenced[1].trim();
+    }
+    const braceStart = trimmed.indexOf("{");
+    const braceEnd = trimmed.lastIndexOf("}");
+    if (braceStart !== -1 && braceEnd !== -1 && braceEnd > braceStart) {
+        return trimmed.slice(braceStart, braceEnd + 1);
+    }
+    return trimmed;
+}
+
+function summarizeCharacter(character) {
+    if (!character || typeof character !== "object") {
+        return "Unknown character";
+    }
+
+    const profile = character.profile && typeof character.profile === "object" ? character.profile : {};
+    const resources = character.resources && typeof character.resources === "object" ? character.resources : {};
+    const gear = character.gear && typeof character.gear === "object" ? character.gear : {};
+
+    const lines = [];
+    const name = safeString(character.name) || "Unnamed adventurer";
+    lines.push(`Name: ${name}`);
+
+    const role = safeString(profile.class) || safeString(profile.concept) || "Adventurer";
+    lines.push(`Role: ${role}`);
+
+    const race = safeString(profile.race);
+    if (race) lines.push(`Race: ${race}`);
+
+    const alignment = safeString(profile.alignment);
+    if (alignment) lines.push(`Alignment: ${alignment}`);
+
+    const arcana = safeString(profile.arcana);
+    if (arcana) lines.push(`Arcana: ${arcana}`);
+
+    const level = Number.parseInt(resources.level, 10);
+    if (Number.isFinite(level)) {
+        lines.push(`Level: ${level}`);
+    }
+
+    const homeland = safeString(profile.nationality);
+    if (homeland) lines.push(`Origin: ${homeland}`);
+
+    const traits = [profile.eye, profile.hair, profile.skinTone, profile.notes]
+        .map((entry) => safeString(entry))
+        .filter(Boolean);
+    if (traits.length > 0) {
+        lines.push(`Physical traits: ${traits.join(", ")}`);
+    }
+
+    const equipment = summarizeEquipment(gear);
+    if (equipment) {
+        lines.push(`Notable equipment: ${equipment}`);
+    }
+
+    const hooks = safeString(profile.background);
+    if (hooks) {
+        lines.push(`Background hooks: ${hooks}`);
+    }
+
+    return lines.join("\n");
+}
+
+function summarizeEquipment(gear) {
+    if (!gear || typeof gear !== "object") return "";
+    const equipped = [];
+    const slots = gear.equipped && typeof gear.equipped === "object" ? gear.equipped : gear;
+    for (const value of Object.values(slots)) {
+        if (!value || typeof value !== "object") continue;
+        const name = safeString(value.name || value.label || value.title);
+        if (name) equipped.push(name);
+    }
+    const extras = Array.isArray(gear.bag)
+        ? gear.bag
+              .map((entry) => safeString(entry?.name || entry?.label))
+              .filter(Boolean)
+              .slice(0, 4)
+        : [];
+    const unique = Array.from(new Set([...equipped, ...extras]));
+    return unique.slice(0, 6).join(", ");
+}
+
+function buildPortraitVariables(character, overrides = {}) {
+    const profile = character?.profile && typeof character.profile === "object" ? character.profile : {};
+    const gear = character?.gear && typeof character.gear === "object" ? character.gear : {};
+
+    const race = safeString(profile.race) || "mysterious adventurer";
+    const role = safeString(profile.class) || safeString(profile.concept) || "hero";
+    const armor = overrides.armor || inferArmor(gear) || "signature battle attire";
+    const setting = overrides.setting || safeString(profile.backgroundLocale || profile.nationality) || "dramatic fantasy scene";
+    const expression = overrides.expression || safeString(profile.expression) || "determined";
+    const style = overrides.style || safeString(profile.style);
+
+    return {
+        race,
+        role,
+        armor,
+        setting,
+        expression,
+        style,
+    };
+}
+
+function inferArmor(gear) {
+    if (!gear || typeof gear !== "object") return "";
+    const slots = gear.equipped && typeof gear.equipped === "object" ? gear.equipped : {};
+    for (const key of ["armor", "body", "torso", "outfit", "clothing"]) {
+        const item = slots[key];
+        const name = safeString(item?.name || item?.label);
+        if (name) return name;
+    }
+    const bag = Array.isArray(gear.bag) ? gear.bag : [];
+    for (const entry of bag) {
+        const name = safeString(entry?.name || entry?.label);
+        if (name) return name;
+    }
+    return "";
+}
+
+const imageChain = RunnableSequence.from([
+    new RunnableLambda({
+        func: async ({ character, overrides }) => ({
+            variables: buildPortraitVariables(character, overrides),
+        }),
+    }),
+    new RunnableLambda({
+        func: async ({ variables }) => ({
+            variables,
+            prompt: await portraitTemplate.format(variables),
+        }),
+    }),
+    new RunnableLambda({
+        func: async ({ prompt, variables }) => ({
+            prompt,
+            variables,
+            image: await callImageEndpoint(prompt, variables?.style),
+        }),
+    }),
+]);
+
+async function callImageEndpoint(prompt, style) {
+    const payload = {
+        prompt,
+        negative_prompt: DEFAULT_NEGATIVE_PROMPT,
+        width: 512,
+        height: 521,
+        guidance_scale: 7.5,
+        steps: 28,
+    };
+
+    if (style) {
+        payload.prompt = `${prompt} Art style: ${style}.`.trim();
+    }
+
+    const response = await fetch(IMAGE_ENDPOINT, {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+        },
+        body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+        const text = await response.text().catch(() => "");
+        throw new Error(`Image generation failed (${response.status}): ${text || response.statusText}`);
+    }
+
+    const contentType = response.headers.get("content-type") || "";
+    if (contentType.includes("application/json")) {
+        const data = await response.json();
+        const raw = data?.image || data?.images?.[0];
+        if (!raw || typeof raw !== "string") {
+            throw new Error("Image response did not include image data.");
+        }
+        if (raw.startsWith("data:")) {
+            return raw;
+        }
+        const format = data?.format || "image/png";
+        return `data:${format};base64,${raw}`;
+    }
+
+    const buffer = await response.arrayBuffer();
+    const mime = contentType || "image/png";
+    const base64 = Buffer.from(buffer).toString("base64");
+    return `data:${mime};base64,${base64}`;
+}
+
+export async function generateCharacterImage(character, overrides = {}) {
+    const { prompt, image } = await imageChain.invoke({ character, overrides });
+    return { prompt, image };
+}
+
+export async function enhanceBackgroundAndNotes(character, background = "", notes = "") {
+    const summary = summarizeCharacter(character);
+    const { background: nextBackground, notes: nextNotes } = await backgroundChain.invoke({
+        summary,
+        background,
+        notes,
+    });
+    return {
+        summary,
+        background: nextBackground || background,
+        notes: nextNotes || notes,
+    };
+}
+


### PR DESCRIPTION
## Summary
- add a LangChain-powered LocalAI service and API routes for portrait and background helper requests
- expose LocalAI helpers on the client and integrate new UI controls to generate portraits and refresh background/notes suggestions
- style the character sheet to surface AI prompt previews and editable suggestion panels

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d9a37d8c2483318f0155dc410b91e8