### PR TITLE
Add admin demon management improvements

### DIFF
--- a/client/src/api.js
+++ b/client/src/api.js
@@ -759,7 +759,11 @@ export const ServerAdmin = {
         list: () => api('/api/admin/demons'),
         update: (id, payload) =>
             api(`/api/admin/demons/${encodeURIComponent(id)}`, { method: 'PATCH', body: payload }),
-        uploadCsv: (csv) => api('/api/admin/demons/upload', { method: 'POST', body: { csv } }),
+        uploadCsv: (csv, options = {}) =>
+            api('/api/admin/demons/upload', {
+                method: 'POST',
+                body: { csv, confirmDeletes: !!options.confirmDeletes },
+            }),
         sync: () => api('/api/admin/demons/sync', { method: 'POST' }),
     },
     masterBot: {

--- a/server/server.js
+++ b/server/server.js
@@ -4655,17 +4655,52 @@ app.post('/api/admin/demons/upload', requireServerAdmin, async (req, res) => {
         return res.status(400).json({ error: 'invalid_csv' });
     }
 
+    const confirmDeletes = req.body?.confirmDeletes === true;
+
     const demons = await loadDemonsFile();
-    const result = applyCsvToDemons({ csvContent, demons });
-    if (result.demonsUpdated === 0) {
+    const result = applyCsvToDemons({
+        csvContent,
+        demons,
+        createMissing: true,
+        deleteMissing: confirmDeletes,
+    });
+
+    if (!confirmDeletes && Array.isArray(result.pendingDeletes) && result.pendingDeletes.length > 0) {
+        return res.json({
+            ok: true,
+            wrote: false,
+            requiresConfirmation: true,
+            rowsProcessed: result.rowsProcessed,
+            demonsUpdated: result.demonsUpdated,
+            demonsCreated: result.demonsCreated,
+            demonsDeleted: 0,
+            changeLog: result.changeLog,
+            mode: result.mode,
+            warnings: result.warnings,
+            pendingDeletes: result.pendingDeletes,
+            created: result.created,
+        });
+    }
+
+    const hasChanges =
+        result.demonsUpdated > 0 ||
+        (Array.isArray(result.created) && result.created.length > 0) ||
+        (confirmDeletes && Array.isArray(result.deleted) && result.deleted.length > 0);
+
+    if (!hasChanges) {
         return res.json({
             ok: true,
             wrote: false,
             rowsProcessed: result.rowsProcessed,
-            demonsUpdated: 0,
+            demonsUpdated: result.demonsUpdated,
+            demonsCreated: result.demonsCreated,
+            demonsDeleted: confirmDeletes ? result.demonsDeleted : 0,
             changeLog: result.changeLog,
             mode: result.mode,
             warnings: result.warnings,
+            pendingDeletes: result.pendingDeletes,
+            created: result.created,
+            deleted: result.deleted,
         });
     }
 
@@ -4677,9 +4712,14 @@ app.post('/api/admin/demons/upload', requireServerAdmin, async (req, res) => {
         backupPath,
         rowsProcessed: result.rowsProcessed,
         demonsUpdated: result.demonsUpdated,
+        demonsCreated: result.demonsCreated,
+        demonsDeleted: confirmDeletes ? result.demonsDeleted : 0,
         changeLog: result.changeLog,
         mode: result.mode,
         warnings: result.warnings,
+        pendingDeletes: result.pendingDeletes,
+        created: result.created,
+        deleted: result.deleted,
     });
 });
 


### PR DESCRIPTION
## Summary
- allow default demon records to upload new artwork and edit ability stats from the admin console
- extend CSV import workflow to add missing demons and confirm removals before syncing
- update admin API to pass through delete confirmations and expose change counts

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d9a5ef45ec8331ba07e00312bd4fae