### PR TITLE
Allow clearing default demon stats and modifiers

### DIFF
--- a/client/src/components/ServerManagementTab.jsx
+++ b/client/src/components/ServerManagementTab.jsx
@@ -553,13 +553,25 @@ function DemonsAdminPanel() {
     const handleSave = async () => {
         if (!selectedDemon || !draft) return;
         const parsedLevel = Number(draft.level);
+        const previousStats = selectedDemon?.stats || {};
+        const previousMods = selectedDemon?.mods || {};
+
         const statsPayload = ABILITY_KEYS.reduce((acc, key) => {
             const raw = draft?.stats?.[key];
-            if (raw === undefined || raw === null || String(raw).trim() === "") {
+            const trimmed = raw === undefined || raw === null ? "" : String(raw).trim();
+            const prev = previousStats[key];
+            const hasPrev = prev !== undefined && prev !== null;
+            const prevNumber = hasPrev ? Number(prev) : null;
+
+            if (trimmed === "") {
+                if (hasPrev) {
+                    acc[key] = null;
+                }
                 return acc;
             }
-            const num = Number(raw);
-            if (Number.isFinite(num)) {
+
+            const num = Number(trimmed);
+            if (Number.isFinite(num) && (!hasPrev || num !== prevNumber)) {
                 acc[key] = num;
             }
             return acc;
@@ -567,11 +579,20 @@ function DemonsAdminPanel() {
 
         const modsPayload = ABILITY_KEYS.reduce((acc, key) => {
             const raw = draft?.mods?.[key];
-            if (raw === undefined || raw === null || String(raw).trim() === "") {
+            const trimmed = raw === undefined || raw === null ? "" : String(raw).trim();
+            const prev = previousMods[key];
+            const hasPrev = prev !== undefined && prev !== null;
+            const prevNumber = hasPrev ? Number(prev) : null;
+
+            if (trimmed === "") {
+                if (hasPrev) {
+                    acc[key] = null;
+                }
                 return acc;
             }
-            const num = Number(raw);
-            if (Number.isFinite(num)) {
+
+            const num = Number(trimmed);
+            if (Number.isFinite(num) && (!hasPrev || num !== prevNumber)) {
                 acc[key] = num;
             }
             return acc;

--- a/server/services/demonCsvImport.js
+++ b/server/services/demonCsvImport.js
@@ -771,10 +771,16 @@ export function updateDemonEntry(entry, updates) {
         }
         if (key === 'stats' || key === 'mods') {
             const source = value && typeof value === 'object' ? value : {};
-            const template = next[key] && typeof next[key] === 'object' ? next[key] : {};
+            const template = next[key] && typeof next[key] === 'object' ? cloneDeep(next[key]) : {};
             const updated = { ...template };
             for (const statKey of ['STR', 'DEX', 'CON', 'INT', 'WIS', 'CHA']) {
-                const raw = Number(source[statKey]);
+                if (!Object.prototype.hasOwnProperty.call(source, statKey)) continue;
+                const rawValue = source[statKey];
+                if (rawValue === null || rawValue === undefined || rawValue === '') {
+                    delete updated[statKey];
+                    continue;
+                }
+                const raw = Number(rawValue);
                 if (Number.isFinite(raw)) {
                     updated[statKey] = raw;
                 }


### PR DESCRIPTION
## Summary
- ensure the Default Demons admin form only sends changed stats/modifiers and signals cleared fields
- update the demon updater to remove stats/modifiers when fields are cleared and avoid mutating existing state

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d9b86e029083318973f5c44f97a751