### PR TITLE
Add admin interface for default items

### DIFF
--- a/client/src/api.js
+++ b/client/src/api.js
@@ -766,6 +766,12 @@ export const ServerAdmin = {
             }),
         sync: () => api('/api/admin/demons/sync', { method: 'POST' }),
     },
+    items: {
+        list: () => api('/api/admin/items'),
+        update: (slug, payload) =>
+            api(`/api/admin/items/${encodeURIComponent(slug)}`, { method: 'PATCH', body: payload }),
+        sync: () => api('/api/admin/items/sync', { method: 'POST' }),
+    },
     masterBot: {
         get: () => api('/api/admin/master-bot', { cache: 2000 }),
         update: (settings) => api('/api/admin/master-bot', { method: 'PUT', body: settings }),

--- a/server/lib/itemImport.js
+++ b/server/lib/itemImport.js
@@ -6,6 +6,10 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, '..');
 export const DEFAULT_ITEMS_PATH = path.join(repoRoot, 'data', 'premade-items.json');
 
+function cloneEntry(entry) {
+    return JSON.parse(JSON.stringify(entry ?? {}));
+}
+
 function truncate(value, max = 1000) {
     if (value == null) return '';
     const str = String(value).trim();
@@ -67,6 +71,37 @@ function determineType(explicitType, category, subcategory) {
 function toArray(value) {
     if (!Array.isArray(value)) return [];
     return value;
+}
+
+function normalizeTagsInput(value) {
+    if (!value) return [];
+    if (Array.isArray(value)) {
+        return value
+            .map((item) => truncate(item, 80))
+            .map((item) => item.trim())
+            .filter(Boolean);
+    }
+    if (typeof value === 'string') {
+        return value
+            .split(',')
+            .map((item) => item.trim())
+            .filter(Boolean)
+            .map((item) => truncate(item, 80));
+    }
+    return [];
+}
+
+function normalizeEffectsInput(effects) {
+    if (!Array.isArray(effects)) return [];
+    return effects
+        .map((effect) => (effect && typeof effect === 'object' ? { ...effect } : null))
+        .filter(Boolean);
+}
+
+function normalizeOrderValue(value, fallback) {
+    const num = Number(value);
+    if (Number.isFinite(num)) return num;
+    return Number.isFinite(fallback) ? fallback : 0;
 }
 
 export function parseHealingEffect(description) {
@@ -225,4 +260,110 @@ export async function loadItemEntries({ file = DEFAULT_ITEMS_PATH } = {}) {
     const parsed = JSON.parse(content);
     const entries = buildEntries(parsed);
     return entries;
+}
+
+export function updateItemEntry(entry, updates = {}) {
+    if (!entry || typeof entry !== 'object') {
+        throw new Error('Invalid item entry');
+    }
+    const next = cloneEntry(entry);
+    const stringFields = ['name', 'type', 'desc', 'category', 'subcategory', 'slot'];
+    for (const field of stringFields) {
+        if (Object.prototype.hasOwnProperty.call(updates, field)) {
+            const value = updates[field];
+            next[field] = truncate(typeof value === 'string' ? value.trim() : '', field === 'desc' ? 1000 : 200);
+        }
+        if (typeof next[field] !== 'string') {
+            next[field] = '';
+        }
+        if (field !== 'desc') {
+            next[field] = truncate(next[field], field === 'type' || field === 'slot' ? 120 : 200);
+        }
+    }
+
+    if (!next.name) {
+        throw new Error('Item name is required');
+    }
+
+    if (Object.prototype.hasOwnProperty.call(updates, 'tags')) {
+        next.tags = normalizeTagsInput(updates.tags);
+    } else if (!Array.isArray(next.tags)) {
+        next.tags = [];
+    } else {
+        next.tags = normalizeTagsInput(next.tags);
+    }
+
+    if (Object.prototype.hasOwnProperty.call(updates, 'order')) {
+        next.order = normalizeOrderValue(updates.order, next.order);
+    } else {
+        next.order = normalizeOrderValue(next.order, 0);
+    }
+
+    if (Object.prototype.hasOwnProperty.call(updates, 'effects')) {
+        next.effects = normalizeEffectsInput(updates.effects);
+    } else if (Array.isArray(next.effects)) {
+        next.effects = normalizeEffectsInput(next.effects);
+    }
+
+    const categoryLabel = cleanLabel(next.category || entry.category || '');
+    const subcategoryLabel = cleanLabel(next.subcategory || entry.subcategory || '');
+    next.category = categoryLabel;
+    next.subcategory = subcategoryLabel;
+    next.type = truncate(next.type || determineType(entry.type, categoryLabel, subcategoryLabel), 120);
+    next.slot = truncate(next.slot, 120);
+    next.desc = truncate(next.desc, 1000);
+
+    const healing = parseHealingEffect(next.desc || '');
+    if (healing) {
+        next.healing = healing;
+    } else {
+        delete next.healing;
+    }
+
+    const slug = buildItemSlug(next.category || next.type || 'item', next.subcategory, next.name);
+    if (slug) {
+        next.slug = slug;
+    } else if (!next.slug) {
+        next.slug = buildItemSlug(next.type || 'item', next.subcategory, next.name);
+    }
+
+    return next;
+}
+
+export function replaceItemInList(items, slug, updated) {
+    const list = Array.isArray(items) ? items.map((item) => cloneEntry(item)) : [];
+    const index = list.findIndex((item) => item?.slug === slug);
+    if (index === -1) {
+        return { items: list, updated: null };
+    }
+    const next = list.slice();
+    next[index] = cloneEntry(updated);
+    return { items: next, updated: cloneEntry(next[index]) };
+}
+
+export async function writeItemEntries(items, { file = DEFAULT_ITEMS_PATH } = {}) {
+    if (!Array.isArray(items)) {
+        throw new Error('items must be an array');
+    }
+
+    const normalized = items.map((item, index) => {
+        if (!item || typeof item !== 'object') {
+            throw new Error('Invalid item entry in list');
+        }
+        const copy = updateItemEntry(item, {});
+        copy.order = normalizeOrderValue(item.order, index);
+        if (!copy.slug) {
+            copy.slug = buildItemSlug(copy.category || copy.type || 'item', copy.subcategory, copy.name);
+        }
+        const effects = normalizeEffectsInput(item.effects || copy.effects);
+        if (effects.length > 0) {
+            copy.effects = effects;
+        } else {
+            delete copy.effects;
+        }
+        return copy;
+    });
+
+    await fs.writeFile(file, `${JSON.stringify(normalized, null, 2)}\n`, 'utf8');
+    return normalized;
 }


### PR DESCRIPTION
## Summary
- add server-side helpers and admin endpoints for managing default item definitions
- expose client API utilities and UI tab for browsing, editing, and syncing default items
- provide backup handling and sync hooks similar to the default demon workflow

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d9c19f7f4883318badcc0727dd12b1