### PR TITLE
Fix LocalAI chat invocation

### DIFF
--- a/server/services/localAi.js
+++ b/server/services/localAi.js
@@ -752,7 +752,7 @@ async function enhanceStableDiffusionPrompt(basePrompt, variables) {
         basePrompt,
         context,
     });
-    const enhanced = await callChatEndpoint(messages);
+    const enhanced = await callChatEndpoint.invoke(messages);
     return cleanEnhancedPrompt(enhanced, basePrompt);
 }
 


### PR DESCRIPTION
## Summary
- call the LocalAI chat runnable via its invoke method when enhancing Stable Diffusion prompts
- prevent callChatEndpoint from being treated as a plain function, avoiding runtime errors when generating player photos

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9c741b11c833185a3892ae7ded744