### PR TITLE
Add portrait reference support and multi-option selection

### DIFF
--- a/client/src/style.css
+++ b/client/src/style.css
@@ -3309,6 +3309,67 @@ label {
     font-size: 0.8rem;
 }
 .sheet-portrait__messages { display: grid; gap: 4px; }
+.sheet-portrait__options {
+    display: grid;
+    gap: 10px;
+    padding: 10px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--surface-2);
+}
+.sheet-portrait__options-text {
+    margin: 0;
+    font-size: 0.85rem;
+}
+.sheet-portrait__options-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 8px;
+}
+.sheet-portrait__option {
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--surface);
+    padding: 0;
+    display: grid;
+    grid-template-rows: 1fr auto;
+    overflow: hidden;
+    cursor: pointer;
+    transition: border-color var(--trans-fast) ease, box-shadow var(--trans-fast) ease;
+}
+.sheet-portrait__option:disabled {
+    cursor: not-allowed;
+    opacity: 0.7;
+}
+.sheet-portrait__option:focus-visible {
+    outline: none;
+    box-shadow: var(--focus);
+    border-color: var(--brand-600);
+}
+.sheet-portrait__option:disabled:hover {
+    border-color: var(--border);
+}
+.sheet-portrait__option:hover {
+    border-color: var(--brand-600);
+}
+.sheet-portrait__option img {
+    display: block;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+.sheet-portrait__option-label {
+    display: block;
+    padding: 6px 8px;
+    font-size: 0.8rem;
+    font-weight: 600;
+    text-align: center;
+    background: var(--surface-2);
+}
+.sheet-portrait__options-actions {
+    display: flex;
+    justify-content: flex-end;
+}
 .sheet-portrait__prompt {
     font-size: 0.85rem;
     border: 1px solid var(--border);
@@ -3332,6 +3393,9 @@ label {
     }
     .sheet-portrait__frame {
         aspect-ratio: 16 / 9;
+    }
+    .sheet-portrait__options-grid {
+        grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
     }
 }
 .section-header {


### PR DESCRIPTION
## Summary
- reuse the existing portrait as a reference image when regenerating a character sheet portrait
- generate four portrait candidates when no portrait exists and prompt the player to choose their favorite in the sheet UI
- extend the LocalAI service to request multiple images, accept reference images, and return the options to the client

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d9d03474e483318a614e7d1740674e