### PR TITLE
Add LocalAI image generation for admin defaults

### DIFF
--- a/client/src/api.js
+++ b/client/src/api.js
@@ -852,6 +852,13 @@ export const LocalAI = {
             timeoutMs: 120_000,
             noRetry: true,
         }),
+    generateConcept: (payload) =>
+        api('/api/ai/concept', {
+            method: 'POST',
+            body: payload,
+            timeoutMs: 120_000,
+            noRetry: true,
+        }),
     enhanceBackground: (payload) =>
         api('/api/ai/background', {
             method: 'POST',

--- a/server/lib/itemImport.js
+++ b/server/lib/itemImport.js
@@ -185,6 +185,7 @@ function normalizeItemRecord(source, { category, subcategory, order }) {
     const normalizedCategory = cleanLabel(category || source.category || '');
     const normalizedSubcategory = cleanLabel(subcategory || source.subcategory || '');
     const slug = buildItemSlug(normalizedCategory || type || 'item', normalizedSubcategory, name);
+    const image = typeof source.image === 'string' ? source.image.trim() : '';
     const healing = parseHealingEffect(desc || source.effect || '');
     return {
         slug,
@@ -196,6 +197,7 @@ function normalizeItemRecord(source, { category, subcategory, order }) {
         slot,
         tags,
         order,
+        image,
         ...(healing ? { healing } : {}),
     };
 }
@@ -305,6 +307,15 @@ export function updateItemEntry(entry, updates = {}) {
         next.effects = normalizeEffectsInput(next.effects);
     }
 
+    if (Object.prototype.hasOwnProperty.call(updates, 'image')) {
+        const value = updates.image;
+        next.image = typeof value === 'string' ? value.trim() : '';
+    } else if (typeof next.image === 'string') {
+        next.image = next.image.trim();
+    } else {
+        next.image = '';
+    }
+
     const categoryLabel = cleanLabel(next.category || entry.category || '');
     const subcategoryLabel = cleanLabel(next.subcategory || entry.subcategory || '');
     next.category = categoryLabel;
@@ -351,6 +362,9 @@ export async function writeItemEntries(items, { file = DEFAULT_ITEMS_PATH } = {}
             throw new Error('Invalid item entry in list');
         }
         const copy = updateItemEntry(item, {});
+        if (!copy.image) {
+            delete copy.image;
+        }
         copy.order = normalizeOrderValue(item.order, index);
         if (!copy.slug) {
             copy.slug = buildItemSlug(copy.category || copy.type || 'item', copy.subcategory, copy.name);

--- a/server/routes/localai.routes.js
+++ b/server/routes/localai.routes.js
@@ -1,9 +1,14 @@
 import { Router } from 'express';
-import { generateCharacterImage, enhanceBackgroundAndNotes } from '../services/localAi.js';
+import { generateCharacterImage, enhanceBackgroundAndNotes, generateConceptImage } from '../services/localAi.js';
 
 const router = Router();
 
 function normalizeCharacterPayload(value) {
+    if (!value || typeof value !== 'object') return {};
+    return value;
+}
+
+function normalizeConceptPayload(value) {
     if (!value || typeof value !== 'object') return {};
     return value;
 }
@@ -16,6 +21,19 @@ router.post('/portrait', async (req, res) => {
         res.json(result);
     } catch (err) {
         console.error('Failed to generate portrait', err);
+        const status = err?.status || 502;
+        res.status(status).json({ error: err?.message || 'Image generation failed' });
+    }
+});
+
+router.post('/concept', async (req, res) => {
+    try {
+        const concept = normalizeConceptPayload(req.body?.concept || req.body);
+        const overrides = req.body?.overrides && typeof req.body.overrides === 'object' ? req.body.overrides : {};
+        const result = await generateConceptImage(concept, overrides);
+        res.json(result);
+    } catch (err) {
+        console.error('Failed to generate concept image', err);
         const status = err?.status || 502;
         res.status(status).json({ error: err?.message || 'Image generation failed' });
     }


### PR DESCRIPTION
## Summary
- allow default item management to upload, paste, or generate images with LocalAI and persist the result
- add LocalAI image generation controls and galleries when editing default demons
- expose a LocalAI concept endpoint and update item persistence to record image data

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d9d821c3c08331834555dc0ebb533b