### PR TITLE
Add shared item detail modal

### DIFF
--- a/client/src/style.css
+++ b/client/src/style.css
@@ -4628,10 +4628,20 @@ img {
     gap: 8px;
     position: relative;
     transition: border-color var(--trans-fast), box-shadow var(--trans-fast);
+    cursor: pointer;
 }
 
 .item-card.is-favorite {
     border-color: var(--brand);
+    box-shadow: var(--focus);
+}
+
+.item-card:focus {
+    outline: none;
+}
+
+.item-card:focus-visible {
+    outline: none;
     box-shadow: var(--focus);
 }
 
@@ -4706,6 +4716,129 @@ img {
     flex-wrap: wrap;
     gap: 8px;
     margin-top: auto;
+}
+
+.item-detail-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(12, 14, 20, 0.55);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 24px;
+    z-index: 40;
+}
+
+.item-detail-modal {
+    pointer-events: auto;
+    background: var(--surface);
+    border-radius: var(--radius-lg);
+    border: 1px solid var(--border);
+    box-shadow: var(--shadow-md);
+    width: min(720px, 96vw);
+    max-height: 90vh;
+    overflow-y: auto;
+    display: grid;
+    gap: 16px;
+    padding: 20px 24px;
+}
+
+.item-detail-modal__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 12px;
+    flex-wrap: wrap;
+}
+
+.item-detail-modal__title-group {
+    display: grid;
+    gap: 6px;
+}
+
+.item-detail-modal__meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    align-items: center;
+}
+
+.item-detail-modal__body {
+    display: grid;
+    gap: 16px;
+}
+
+.item-detail-modal__image {
+    border-radius: var(--radius);
+    overflow: hidden;
+    border: 1px solid var(--border);
+    background: var(--surface-2);
+    max-height: 320px;
+}
+
+.item-detail-modal__image img {
+    display: block;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.item-detail-modal__section {
+    display: grid;
+    gap: 12px;
+}
+
+.item-detail-modal__section--library {
+    border-top: 1px solid var(--border);
+    padding-top: 12px;
+}
+
+.item-detail-modal__tags {
+    display: grid;
+    gap: 6px;
+}
+
+.item-detail-modal__tag-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+
+.item-detail-modal__section-title {
+    font-weight: 600;
+}
+
+.item-detail-modal__effects {
+    display: grid;
+    gap: 4px;
+}
+
+.item-detail-modal__effects ul {
+    margin: 4px 0 0;
+    padding-left: 20px;
+    display: grid;
+    gap: 4px;
+    font-size: 0.85rem;
+    color: var(--muted);
+    list-style: disc;
+}
+
+.item-detail-modal__healing {
+    font-weight: 600;
+    color: var(--success);
+}
+
+.item-detail-modal__library-title {
+    font-weight: 600;
+}
+
+.item-detail-modal__library-id {
+    font-size: 0.75rem;
+    color: var(--muted);
+}
+
+.item-detail-modal__library-desc {
+    color: var(--muted);
 }
 
 .favorite-toggle {


### PR DESCRIPTION
## Summary
- make player inventory cards open an item detail dialog with full information and support for linked library data
- add helper logic for trigger effect display and persist selection state for the modal
- style the new modal and adjust card focus to reflect their interactivity

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9e0ef0c5c8331a482d22cdce4db0b