### PR TITLE
Improve Discord bot stability and add linking command

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,23 +177,17 @@ If no per-campaign token is supplied, the server falls back to `DISCORD_PRIMARY_
 
 ### Slash command codex lookup
 
-A lightweight gateway client powers the `/lookup demon <name>` slash command. To enable it:
+A lightweight gateway client powers the `/demonLookup <name>` slash command. It also exposes `/link <username>` so players can bind their Discord account to a Jack Endex profile. To enable it:
 
-1. Set `DISCORD_APPLICATION_ID` and `DISCORD_PRIMARY_BOT_TOKEN` in your `.env`. Optionally set `DISCORD_COMMAND_GUILD_ID` for per-guild registration and `DISCORD_PRIMARY_BOT_INVITE` so DMs can invite the shared bot to their own servers.
+1. Set `DISCORD_APPLICATION_ID` and `DISCORD_PRIMARY_BOT_TOKEN` in your `.env`. Optionally set `DISCORD_COMMAND_GUILD_ID` for per-guild command registration and `DISCORD_PRIMARY_BOT_INVITE` so DMs can invite the shared bot to their own servers.
 
-2. Register the command with Discord:
-
-   ```bash
-   npm run register:discord
-   ```
-
-3. Run the lookup bot (ensure MongoDB is reachable so it can query the codex):
+2. Run the lookup bot (ensure MongoDB is reachable so it can query the codex):
 
    ```bash
    npm run bot:demon
    ```
 
-The bot listens for slash-command interactions and responds with a formatted codex summary, including close-match suggestions for typos.
+The bot automatically registers or updates its slash commands at startup. `/demonLookup` responds with a formatted codex summary (including close-match suggestions for typos), and `/link` stores the invoking Discord user’s ID on the matching Jack Endex account.
 
 ## Helpful scripts
 
@@ -201,7 +195,7 @@ The bot listens for slash-command interactions and responds with a formatted cod
 | --- | --- |
 | `npm run import:demons` | Convert `server/data/demons.json` into MongoDB documents (use `--dry-run` to preview). |
 | `npm run test:import` | Runs the demon import in dry-run mode to confirm the mapping step. |
-| `npm run register:discord` | Registers or updates the `/lookup demon` slash command. |
+| `npm run register:discord` | (Legacy) Manual slash-command registration. The bot now registers commands automatically on start. |
 | `npm run bot:demon` | Starts the Discord gateway bot that powers the slash command. |
 | `npm run dev` | Runs the API server and Vite dev client together. |
 | `npm run start` | Launches the API server only (expects a built client in `dist/`). |

--- a/server/bot/demonLookupBot.js
+++ b/server/bot/demonLookupBot.js
@@ -3,6 +3,7 @@ import { fileURLToPath } from 'url';
 import WebSocket from 'ws';
 import { loadEnv, envString, envNumber } from '../config/env.js';
 import mongoose from '../lib/mongoose.js';
+import User from '../models/User.js';
 import {
     searchDemons,
     findDemonBySlug,
@@ -23,8 +24,18 @@ const token = envString('DISCORD_PRIMARY_BOT_TOKEN')
     || envString('BOT_TOKEN');
 const uri = envString('MONGODB_URI');
 const dbName = envString('MONGODB_DB_NAME');
+const applicationId = envString('DISCORD_APPLICATION_ID');
+const commandGuildId = envString('DISCORD_COMMAND_GUILD_ID')
+    || envString('DISCORD_PRIMARY_GUILD_ID')
+    || envString('DISCORD_GUILD_ID')
+    || envString('DISCORD_SERVER_ID');
 const DB_CONNECT_MAX_ATTEMPTS = Math.max(1, envNumber('BOT_MONGODB_CONNECT_MAX_ATTEMPTS', 5) || 5);
 const DB_CONNECT_RETRY_DELAY_MS = Math.max(500, envNumber('BOT_MONGODB_CONNECT_RETRY_MS', 2000) || 2000);
+const COMMAND_REGISTER_MAX_ATTEMPTS = Math.max(1, envNumber('BOT_COMMAND_REGISTER_MAX_ATTEMPTS', 3) || 3);
+const COMMAND_REGISTER_RETRY_DELAY_MS = Math.max(
+    1_000,
+    envNumber('BOT_COMMAND_REGISTER_RETRY_MS', 2_000) || 2_000,
+);
 
 if (!token) {
     console.error('Missing bot token. Set DISCORD_PRIMARY_BOT_TOKEN or DISCORD_BOT_TOKEN in your .env file.');
@@ -68,6 +79,10 @@ async function connectToDatabaseWithRetry(
 
 try {
     await connectToDatabaseWithRetry(uri, { dbName: dbName || undefined });
+    await registerSlashCommandsWithRetry().catch((err) => {
+        console.error('[bot] Slash command registration failed:', err);
+        throw err;
+    });
     console.log('[bot] Connected to MongoDB. Starting gateway connection…');
 } catch (err) {
     console.error('[bot] Failed to prepare bot. Exiting.', err);
@@ -90,6 +105,35 @@ const RESISTANCE_ALIAS_MAP = {
     drain: ['drain', 'drains', 'absorb', 'absorbs'],
     reflect: ['reflect', 'reflects'],
 };
+
+const COMMAND_DEFINITIONS = [
+    {
+        name: 'demonLookup',
+        description: 'Look up codex information for a demon.',
+        type: 1,
+        options: [
+            {
+                name: 'name',
+                description: 'Name of the demon to search for.',
+                type: 3,
+                required: true,
+            },
+        ],
+    },
+    {
+        name: 'link',
+        description: 'Link your Discord account to your Jack Endex profile.',
+        type: 1,
+        options: [
+            {
+                name: 'username',
+                description: 'Your Jack Endex username.',
+                type: 3,
+                required: true,
+            },
+        ],
+    },
+];
 
 function getResistanceValues(demon, key) {
     if (!demon) return [];
@@ -121,6 +165,90 @@ function getResistanceValues(demon, key) {
 function truncate(text, max = 1024) {
     if (!text) return '';
     return text.length <= max ? text : `${text.slice(0, max - 1)}…`;
+}
+
+function escapeRegex(value) {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function getOptionValue(interaction, optionName) {
+    const options = interaction?.data?.options;
+    if (!Array.isArray(options)) return null;
+    const option = options.find((opt) => opt?.name === optionName);
+    return option?.value ?? null;
+}
+
+function getDiscordUserId(interaction) {
+    return interaction?.member?.user?.id
+        || interaction?.user?.id
+        || null;
+}
+
+async function discordFetch(endpoint, { headers = {}, ...options } = {}) {
+    const url = endpoint.startsWith('http') ? endpoint : `${API_BASE}${endpoint}`;
+    const response = await fetch(url, {
+        ...options,
+        headers: {
+            Authorization: `Bot ${token}`,
+            ...headers,
+        },
+    });
+    if (!response.ok) {
+        const text = await response.text().catch(() => '');
+        const error = new Error(
+            `Discord API request failed with ${response.status} ${response.statusText}: ${text}`,
+        );
+        error.status = response.status;
+        error.statusText = response.statusText;
+        error.body = text;
+        throw error;
+    }
+    return response;
+}
+
+async function registerSlashCommands() {
+    if (!applicationId) {
+        console.warn('[bot] Missing DISCORD_APPLICATION_ID; skipping command registration.');
+        return;
+    }
+    const scopeDescription = commandGuildId ? `guild ${commandGuildId}` : 'global';
+    const route = commandGuildId
+        ? `/applications/${applicationId}/guilds/${commandGuildId}/commands`
+        : `/applications/${applicationId}/commands`;
+    const response = await discordFetch(route, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(COMMAND_DEFINITIONS),
+    });
+    let payload;
+    try {
+        payload = await response.json();
+    } catch {
+        payload = null;
+    }
+    const count = Array.isArray(payload) ? payload.length : COMMAND_DEFINITIONS.length;
+    console.log(`[bot] Registered ${count} slash command(s) for ${scopeDescription}.`);
+}
+
+async function registerSlashCommandsWithRetry({
+    attempts = COMMAND_REGISTER_MAX_ATTEMPTS,
+    delayMs = COMMAND_REGISTER_RETRY_DELAY_MS,
+} = {}) {
+    for (let attempt = 1; attempt <= attempts; attempt += 1) {
+        try {
+            await registerSlashCommands();
+            return;
+        } catch (err) {
+            if (attempt >= attempts) {
+                throw err;
+            }
+            const waitMs = Math.min(delayMs * 2 ** (attempt - 1), 30_000);
+            console.warn(
+                `[bot] Failed to register slash commands (attempt ${attempt}/${attempts}). Retrying in ${waitMs}ms…`,
+            );
+            await delay(waitMs);
+        }
+    }
 }
 
 function formatDemonResponse(demon) {
@@ -179,111 +307,276 @@ async function respond(interaction, payload) {
     });
 }
 
-async function handleInteraction(interaction) {
-    if (interaction.type !== 2) return; // application command
-    const name = interaction.data?.name;
-    if (name !== 'lookup') return;
-    const sub = interaction.data?.options?.[0];
-    if (!sub || sub.name !== 'demon') {
-        await respond(interaction, { content: 'Unknown subcommand.' });
-        return;
-    }
-    const option = Array.isArray(sub.options)
-        ? sub.options.find((opt) => opt.name === 'name')
-        : null;
-    const term = option?.value || option?.name || '';
-    if (!term) {
+async function handleDemonLookupCommand(interaction) {
+    const term = getOptionValue(interaction, 'name');
+    if (!term || !String(term).trim()) {
         await respond(interaction, { content: 'Provide a demon name to look up.' });
         return;
     }
+    const query = String(term).trim();
     try {
-        const demon = await resolveDemon(String(term));
+        const demon = await resolveDemon(query);
         if (demon) {
             const message = formatDemonResponse(demon);
             await respond(interaction, { content: message });
+            return;
+        }
+        const suggestion = await findClosestDemon(query);
+        if (suggestion) {
+            await respond(interaction, {
+                content: `No exact match. Did you mean **${suggestion.name}**? Try \`/demonLookup ${suggestion.name}\`.`,
+            });
         } else {
-            const suggestion = await findClosestDemon(String(term));
-            if (suggestion) {
-                await respond(interaction, {
-                    content: `No exact match. Did you mean **${suggestion.name}**? Try \`/lookup demon ${suggestion.name}\`.`,
-                });
-            } else {
-                await respond(interaction, { content: `No demon found matching **${term}**.` });
-            }
+            await respond(interaction, { content: `No demon found matching **${query}**.` });
         }
     } catch (err) {
-        console.error('Failed to handle interaction:', err);
+        console.error('[bot] Failed to process demon lookup:', err);
         await respond(interaction, { content: 'Something went wrong looking up that demon.' });
     }
 }
 
+async function handleLinkCommand(interaction) {
+    const discordUserId = getDiscordUserId(interaction);
+    if (!discordUserId) {
+        await respond(interaction, { content: 'Unable to determine your Discord user ID.' });
+        return;
+    }
+    const usernameInput = getOptionValue(interaction, 'username');
+    const normalized = typeof usernameInput === 'string' ? usernameInput.trim() : '';
+    if (!normalized) {
+        await respond(interaction, { content: 'Provide the Jack Endex username you want to link.' });
+        return;
+    }
+    try {
+        const user = await User.findOne({
+            username: { $regex: `^${escapeRegex(normalized)}$`, $options: 'i' },
+        }).exec();
+        if (!user) {
+            await respond(interaction, {
+                content: `No Jack Endex account found for **${normalized}**. Check the spelling and try again.`,
+            });
+            return;
+        }
+        if (user.discordId && user.discordId !== discordUserId) {
+            await respond(interaction, {
+                content: 'That Jack Endex account is already linked to a different Discord user.',
+            });
+            return;
+        }
+        const existingLink = await User.findOne({
+            _id: { $ne: user._id },
+            discordId: discordUserId,
+        }).exec();
+        if (existingLink) {
+            await respond(interaction, {
+                content: `Your Discord account is already linked to **${existingLink.username}**.`,
+            });
+            return;
+        }
+        if (user.discordId === discordUserId) {
+            await respond(interaction, {
+                content: `Your Discord account is already linked to **${user.username}**.`,
+            });
+            return;
+        }
+        user.discordId = discordUserId;
+        await user.save();
+        await respond(interaction, {
+            content: `Success! Your Discord account is now linked to **${user.username}**.`,
+        });
+    } catch (err) {
+        console.error('[bot] Failed to link Discord account:', err);
+        await respond(interaction, {
+            content: 'Something went wrong while linking your account. Please try again later.',
+        });
+    }
+}
+
+async function handleInteraction(interaction) {
+    if (interaction.type !== 2) return; // application command
+    const commandName = interaction.data?.name;
+    if (!commandName) return;
+    if (commandName === 'demonLookup') {
+        await handleDemonLookupCommand(interaction);
+        return;
+    }
+    if (commandName === 'link') {
+        await handleLinkCommand(interaction);
+        return;
+    }
+}
+
+let shuttingDown = false;
+let sessionId = null;
+let lastSequence = null;
+let resumeGatewayUrl = null;
+
 function startGateway() {
     let ws;
     let heartbeatInterval = null;
-    let sequence = null;
+    let heartbeatTimeout = null;
+    let heartbeatIntervalMs = 0;
+    let awaitingHeartbeatAck = false;
+    let reconnectTimer = null;
+    let reconnectAttempts = 0;
 
-    function cleanup() {
+    function clearHeartbeat() {
         if (heartbeatInterval) {
             clearInterval(heartbeatInterval);
             heartbeatInterval = null;
         }
+        if (heartbeatTimeout) {
+            clearTimeout(heartbeatTimeout);
+            heartbeatTimeout = null;
+        }
+        awaitingHeartbeatAck = false;
+        heartbeatIntervalMs = 0;
+    }
+
+    function cleanup() {
+        clearHeartbeat();
+        if (reconnectTimer) {
+            clearTimeout(reconnectTimer);
+            reconnectTimer = null;
+        }
+    }
+
+    function scheduleReconnect(baseDelayMs = 1_000) {
+        if (shuttingDown) return;
+        if (reconnectTimer) {
+            clearTimeout(reconnectTimer);
+        }
+        const delay = Math.min(baseDelayMs * 2 ** reconnectAttempts, 30_000);
+        console.warn(`[bot] Reconnecting in ${delay}ms…`);
+        reconnectTimer = setTimeout(() => {
+            reconnectAttempts += 1;
+            connect();
+        }, delay);
+    }
+
+    function sendHeartbeat() {
+        if (!ws || ws.readyState !== WebSocket.OPEN) return;
+        if (awaitingHeartbeatAck) {
+            console.warn('[bot] Missed heartbeat acknowledgement. Terminating connection…');
+            ws.terminate();
+            return;
+        }
+        ws.send(JSON.stringify({ op: 1, d: lastSequence }));
+        awaitingHeartbeatAck = true;
+        if (heartbeatTimeout) clearTimeout(heartbeatTimeout);
+        heartbeatTimeout = setTimeout(() => {
+            if (awaitingHeartbeatAck && ws?.readyState === WebSocket.OPEN) {
+                console.warn('[bot] Heartbeat acknowledgement timeout. Terminating connection…');
+                ws.terminate();
+            }
+        }, Math.max(1_000, Math.floor(heartbeatIntervalMs * 0.5) || 5_000));
     }
 
     function connect() {
-        ws = new WebSocket(GATEWAY_URL);
+        if (reconnectTimer) {
+            clearTimeout(reconnectTimer);
+            reconnectTimer = null;
+        }
+        const gatewayUrl = resumeGatewayUrl || GATEWAY_URL;
+        ws = new WebSocket(gatewayUrl);
+
+        ws.on('open', () => {
+            reconnectAttempts = 0;
+        });
 
         ws.on('message', async (data) => {
-            const payload = JSON.parse(data.toString());
+            let payload;
+            try {
+                payload = JSON.parse(data.toString());
+            } catch (err) {
+                console.error('[bot] Failed to parse gateway payload:', err);
+                return;
+            }
             const { op, t, d, s } = payload;
             if (s !== null && s !== undefined) {
-                sequence = s;
+                lastSequence = s;
             }
             switch (op) {
-                case 1: { // Heartbeat request
-                    if (ws.readyState === WebSocket.OPEN) {
-                        ws.send(JSON.stringify({ op: 1, d: sequence }));
-                    }
-                    break;
-                }
-                case 10: { // Hello
-                    cleanup();
-                    heartbeatInterval = setInterval(() => {
-                        if (ws.readyState === WebSocket.OPEN) {
-                            ws.send(JSON.stringify({ op: 1, d: sequence }));
-                        }
-                    }, d.heartbeat_interval);
-                    ws.send(JSON.stringify({
-                        op: 2,
-                        d: {
-                            token,
-                            intents: 0,
-                            properties: {
-                                os: process.platform,
-                                browser: 'jack-endex',
-                                device: 'jack-endex',
-                            },
-                        },
-                    }));
-                    break;
-                }
                 case 0: {
                     if (t === 'READY') {
-                        console.log(`[bot] Logged in as ${d.user?.username ?? 'bot'}.`);
+                        sessionId = d.session_id;
+                        resumeGatewayUrl = d.resume_gateway_url || GATEWAY_URL;
+                        console.log(`[bot] Logged in as ${d.user?.username ?? 'bot'} (${sessionId}).`);
+                    } else if (t === 'RESUMED') {
+                        console.log('[bot] Successfully resumed previous gateway session.');
                     } else if (t === 'INTERACTION_CREATE') {
-                        await handleInteraction(d);
+                        try {
+                            await handleInteraction(d);
+                        } catch (err) {
+                            console.error('[bot] Unexpected error handling interaction:', err);
+                        }
                     }
+                    break;
+                }
+                case 1: { // Heartbeat request
+                    sendHeartbeat();
                     break;
                 }
                 case 7: { // Reconnect
                     console.log('[bot] Gateway requested reconnect.');
-                    cleanup();
+                    clearHeartbeat();
                     ws.close(4000, 'Reconnect requested');
                     break;
                 }
-                case 9: {
-                    console.warn('[bot] Invalid session. Re-identifying…');
-                    cleanup();
-                    ws.close(4001, 'Invalid session');
+                case 9: { // Invalid session
+                    const resumable = Boolean(d);
+                    if (!resumable) {
+                        sessionId = null;
+                        resumeGatewayUrl = null;
+                        lastSequence = null;
+                    }
+                    console.warn(`[bot] Invalid session received (resumable=${resumable}).`);
+                    clearHeartbeat();
+                    setTimeout(() => {
+                        if (ws.readyState === WebSocket.OPEN) {
+                            ws.close(4001, 'Invalid session');
+                        }
+                    }, Math.floor(Math.random() * 4_000) + 1_000);
+                    break;
+                }
+                case 10: { // Hello
+                    clearHeartbeat();
+                    heartbeatIntervalMs = Math.max(1_000, Math.floor(d.heartbeat_interval));
+                    heartbeatInterval = setInterval(() => {
+                        sendHeartbeat();
+                    }, heartbeatIntervalMs);
+                    sendHeartbeat();
+                    if (sessionId && lastSequence !== null) {
+                        ws.send(JSON.stringify({
+                            op: 6,
+                            d: {
+                                token,
+                                session_id: sessionId,
+                                seq: lastSequence,
+                            },
+                        }));
+                    } else {
+                        ws.send(JSON.stringify({
+                            op: 2,
+                            d: {
+                                token,
+                                intents: 0,
+                                properties: {
+                                    os: process.platform,
+                                    browser: 'jack-endex',
+                                    device: 'jack-endex',
+                                },
+                            },
+                        }));
+                    }
+                    break;
+                }
+                case 11: { // Heartbeat ACK
+                    awaitingHeartbeatAck = false;
+                    if (heartbeatTimeout) {
+                        clearTimeout(heartbeatTimeout);
+                        heartbeatTimeout = null;
+                    }
                     break;
                 }
                 default:
@@ -293,23 +586,51 @@ function startGateway() {
 
         ws.on('close', (code) => {
             cleanup();
-            console.warn(`[bot] Gateway closed (${code}). Reconnecting in 5s…`);
-            setTimeout(connect, 5000);
+            if (shuttingDown) return;
+            console.warn(`[bot] Gateway closed (${code}).`);
+            scheduleReconnect(1_000);
         });
 
         ws.on('error', (err) => {
             console.error('[bot] Gateway error:', err);
-            ws.close(1011, 'error');
+            if (ws.readyState === WebSocket.OPEN) {
+                ws.close(1011, 'Gateway error');
+            }
         });
     }
 
     connect();
+
+    return () => {
+        shuttingDown = true;
+        if (reconnectTimer) {
+            clearTimeout(reconnectTimer);
+            reconnectTimer = null;
+        }
+        cleanup();
+        if (ws && (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING)) {
+            try {
+                ws.close(1001, 'Bot shutting down');
+            } catch (err) {
+                console.error('[bot] Error closing gateway during shutdown:', err);
+            }
+        }
+        ws = null;
+    };
 }
 
-startGateway();
+const stopGateway = startGateway();
 
 async function gracefulShutdown(signal) {
     console.log(`\n[bot] Received ${signal}. Shutting down…`);
+    shuttingDown = true;
+    if (typeof stopGateway === 'function') {
+        try {
+            await stopGateway();
+        } catch (err) {
+            console.error('[bot] Error stopping gateway:', err);
+        }
+    }
     try {
         await mongoose.disconnect();
     } catch (err) {

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -12,6 +12,12 @@ const userSchema = new mongoose.Schema(
             unique: true,
             sparse: true,
         },
+        discordId: {
+            type: String,
+            unique: true,
+            sparse: true,
+            index: true,
+        },
         banned: { type: Boolean, default: false },
     },
     {


### PR DESCRIPTION
## Summary
- harden the Discord gateway client with heartbeat tracking, resumable sessions, and automatic slash-command registration
- add the `/demonLookup` handler updates plus a new `/link` command that ties a Discord user to a Jack Endex account
- extend the user model with a Discord snowflake field and update the documentation to reflect the new workflow

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d9eaab036083319751daa7ffd7da77