### PR TITLE
Refactor Discord bot to use discord.js client

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@langchain/langgraph": "^0.4.9",
     "@langchain/openai": "^0.6.13",
     "axios": "^1.12.2",
+    "discord.js": "^14.14.1",
     "cors": "^2.8.5",
     "express": "^4.19.2",
     "express-session": "^1.18.0",


### PR DESCRIPTION
## Summary
- replace the custom WebSocket gateway client with a discord.js Client
- dynamically register slash commands including /codex, /demonlookup, /link, /unlink, and /whoami
- add new handlers for linking state management and declare the discord.js dependency

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68da95417cd08331a873b3f1c1782e2f