### PR TITLE
Normalize ID handling to restore DM navigation

### DIFF
--- a/client/src/components/DemonTab.jsx
+++ b/client/src/components/DemonTab.jsx
@@ -21,6 +21,7 @@ import {
     resolveAbilityState,
 } from "../constants/gameData";
 import { EMPTY_ARRAY, EMPTY_OBJECT } from "../utils/constants";
+import { idsMatch } from "../utils/ids";
 import {
     FUSION_OVERRIDE_RANDOM,
     MOON_PHASE_OPTIONS,
@@ -1056,7 +1057,7 @@ function DemonTab({ game, me, onUpdate }) {
     );
     const combatSkills = useMemo(() => normalizeCombatSkillDefs(game.combatSkills), [game.combatSkills]);
 
-    const isDM = game.dmId === me.id;
+    const isDM = idsMatch(game.dmId, me.id);
     const canEdit = isDM || game.permissions?.canEditDemons;
     const [activeSubTab, setActiveSubTab] = useState("shared");
 

--- a/client/src/components/ItemsGearTabs.jsx
+++ b/client/src/components/ItemsGearTabs.jsx
@@ -8,6 +8,7 @@ import {
     isConsumableType,
     isGearCategory,
 } from "../utils/items";
+import { idsMatch } from "../utils/ids";
 
 const INVENTORY_SORT_OPTIONS = [
     { value: "name", label: "Name" },
@@ -355,7 +356,7 @@ function ItemsTab({ game, me, onUpdate, realtime }) {
     const [sortMode, setSortMode] = useState(INVENTORY_SORT_OPTIONS[0]?.value || "name");
     const [favoritesOnly, setFavoritesOnly] = useState(false);
 
-    const isDM = game.dmId === me.id;
+    const isDM = idsMatch(game.dmId, me.id);
     const canEdit = isDM || game.permissions?.canEditItems;
 
     const { favorites, toggleFavorite, isFavorite, clearMissing } = useItemFavorites(game.id, me.id);
@@ -2803,7 +2804,7 @@ function GearTab({ game, me, onUpdate }) {
     const [selectedPlayerId, setSelectedPlayerId] = useState("");
     const [giveBusyId, setGiveBusyId] = useState(null);
 
-    const isDM = game.dmId === me.id;
+    const isDM = idsMatch(game.dmId, me.id);
     const canEdit = isDM || game.permissions?.canEditGear;
 
     const resetForm = useCallback(() => {

--- a/client/src/components/WorldSkillsTab.jsx
+++ b/client/src/components/WorldSkillsTab.jsx
@@ -20,12 +20,13 @@ import {
 import { WORLD_SKILL_REFERENCE } from "../constants/referenceContent";
 import { get } from "../utils/object";
 import { deepClone, normalizeCharacter, normalizeSkills } from "../utils/character";
+import { idsMatch } from "../utils/ids";
 
 import MathField from "./MathField";
 import { createEmptySkillViewPrefs, sanitizeSkillViewPrefs } from "../utils/skillViewPrefs";
 
 function WorldSkillsTab({ game, me, onUpdate }) {
-    const isDM = game.dmId === me.id;
+    const isDM = idsMatch(game.dmId, me.id);
     const abilityDefault = ABILITY_DEFS[0]?.key || "INT";
     const worldSkills = useMemo(() => normalizeWorldSkillDefs(game.worldSkills), [game.worldSkills]);
     const [skillQuery, setSkillQuery] = useState("");

--- a/client/src/components/battleMap/MapTab.jsx
+++ b/client/src/components/battleMap/MapTab.jsx
@@ -4,6 +4,7 @@ import useBattleLogger from "../../hooks/useBattleLogger";
 import RealtimeContext from "../../contexts/RealtimeContext";
 import DemonImage from "../DemonImage";
 import { MAP_DEFAULT_SETTINGS, mapReadBoolean, describePlayerName } from "./mapShared";
+import { idsMatch } from "../../utils/ids";
 
 const MAP_BRUSH_COLORS = ['#f97316', '#38bdf8', '#a855f7', '#22c55e', '#f472b6'];
 const MAP_BRUSH_STORAGE_KEY = 'battlemap.brushPalette';
@@ -1666,7 +1667,7 @@ function describeDemonTooltip(demon) {
 }
 
 function MapTab({ game, me }) {
-    const isDM = game.dmId === me.id;
+    const isDM = idsMatch(game.dmId, me.id);
     const realtime = useContext(RealtimeContext);
     const logBattle = useBattleLogger(game.id);
     const sidebarTabs = useMemo(
@@ -2076,7 +2077,7 @@ function MapTab({ game, me }) {
         if (game.dmId) {
             options.push({
                 id: game.dmId,
-                label: `Dungeon Master${game.dmId === me.id ? ' (you)' : ''}`,
+                label: `Dungeon Master${idsMatch(game.dmId, me.id) ? ' (you)' : ''}`,
             });
         }
         if (Array.isArray(game.players)) {

--- a/client/src/utils/ids.js
+++ b/client/src/utils/ids.js
@@ -1,0 +1,22 @@
+export function normalizeId(value) {
+    if (value === null || value === undefined) return null;
+    if (typeof value === "string") {
+        const trimmed = value.trim();
+        return trimmed || null;
+    }
+    if (typeof value === "number") {
+        if (!Number.isFinite(value)) return null;
+        return String(value);
+    }
+    if (typeof value === "bigint") {
+        return value.toString();
+    }
+    return null;
+}
+
+export function idsMatch(a, b) {
+    const left = normalizeId(a);
+    const right = normalizeId(b);
+    if (!left || !right) return false;
+    return left === right;
+}


### PR DESCRIPTION
## Summary
- normalize game and player identifiers when loading state so DM navigation and tab selection stay in sync
- add shared id helpers and use tolerant ID comparison in DM-facing views and navigation
- update DM-specific tabs to rely on normalized IDs and shared matching logic

## Testing
- Not run (npm install blocked: npm error 403 fetching @testing-library/jest-dom)


------
https://chatgpt.com/codex/tasks/task_e_68db677d8c0c8331b24019ac8dcd8773