### PR TITLE
Ensure navigation sidebar visible on desktop

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1428,13 +1428,13 @@ function GameView({
     const isDM = idsMatch(game.dmId, me.id);
     const [apiBusy, setApiBusy] = useState(false);
     const [refreshBusy, setRefreshBusy] = useState(false);
-    const [isDesktop, setIsDesktop] = useState(() =>
-        typeof window === "undefined" ? true : window.innerWidth >= 960
-    );
-    const [sidebarOpen, setSidebarOpen] = useState(false);
+    const initialDesktop = typeof window === "undefined" ? true : window.innerWidth >= 960;
+    const [isDesktop, setIsDesktop] = useState(initialDesktop);
+    const [sidebarOpen, setSidebarOpen] = useState(initialDesktop);
     const [logoutBusy, setLogoutBusy] = useState(false);
     const loadedTabRef = useRef(false);
     const loadedSheetRef = useRef(false);
+    const previousIsDesktopRef = useRef(initialDesktop);
     const showServerManagement = isServerAdminClient(me);
 
     useEffect(() => {
@@ -1517,6 +1517,16 @@ function GameView({
     const closeSidebar = useCallback(() => {
         hideSidebar("close-button");
     }, [hideSidebar]);
+
+    useEffect(() => {
+        const previous = previousIsDesktopRef.current;
+        if (isDesktop && !previous) {
+            updateSidebarOpen(true, "layout-breakpoint");
+        } else if (!isDesktop && previous) {
+            updateSidebarOpen(false, "layout-breakpoint");
+        }
+        previousIsDesktopRef.current = isDesktop;
+    }, [isDesktop, updateSidebarOpen]);
 
     useEffect(() => {
         if (navItems.length === 0) return;


### PR DESCRIPTION
## Summary
- default the in-game navigation sidebar to open on desktop layouts so the tab controls are visible when a game loads
- track viewport breakpoint changes and automatically reopen or collapse the sidebar to keep every tab reachable when switching between desktop and mobile widths

## Testing
- npm test -- --runInBand *(fails: vitest executable missing in environment)*
- npm run lint *(fails: @eslint/js package missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dbbabb0f2883318463bd436bb9de40