### PR TITLE
Handle Discord OAuth start fallback redirect

### DIFF
--- a/server/routes/__tests__/discordOAuthStart.handler.test.js
+++ b/server/routes/__tests__/discordOAuthStart.handler.test.js
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createDiscordOAuthStartHandler } from '../discordOAuthStart.handler.js';
+import {
+    sanitizeDiscordRedirectPath,
+    buildDiscordOAuthRedirectLocation,
+} from '../../lib/discordOAuthRedirect.js';
+
+function createResponseStub() {
+    return {
+        statusCode: undefined,
+        body: undefined,
+        status(code) {
+            this.statusCode = code;
+            return this;
+        },
+        json(payload) {
+            this.body = payload;
+            return this;
+        },
+    };
+}
+
+describe('createDiscordOAuthStartHandler', () => {
+    it('redirects with sanitized fallback when OAuth is not configured', async () => {
+        const redirectWithSession = vi.fn(async (_req, _res, location) => {
+            return location;
+        });
+
+        const handler = createDiscordOAuthStartHandler({
+            getMasterBotSettings: async () => ({ oauthClientId: '', oauthRedirectUri: '' }),
+            sanitizeDiscordRedirectPath,
+            buildDiscordOAuthRedirectLocation,
+            redirectWithSession,
+            randomState: () => 'state-token',
+            logger: { error: vi.fn() },
+            authorizeUrl: 'https://discord.com/oauth2/authorize',
+            scopes: ['identify', 'guilds'],
+        });
+
+        const req = { query: { redirect: '/login' }, session: {} };
+        const res = createResponseStub();
+
+        await handler(req, res);
+
+        expect(redirectWithSession).toHaveBeenCalledTimes(1);
+        expect(redirectWithSession).toHaveBeenCalledWith(
+            req,
+            res,
+            '/login?discordError=discord_oauth_not_configured',
+        );
+        expect(res.statusCode).toBeUndefined();
+        expect(res.body).toBeUndefined();
+        expect(req.session.discordOAuth).toBeUndefined();
+    });
+});

--- a/server/routes/discordOAuthStart.handler.js
+++ b/server/routes/discordOAuthStart.handler.js
@@ -1,0 +1,90 @@
+import { URL } from 'url';
+
+export function createDiscordOAuthStartHandler({
+    getMasterBotSettings,
+    sanitizeDiscordRedirectPath,
+    buildDiscordOAuthRedirectLocation,
+    redirectWithSession,
+    randomState,
+    logger,
+    authorizeUrl,
+    scopes,
+}) {
+    if (typeof getMasterBotSettings !== 'function') {
+        throw new TypeError('createDiscordOAuthStartHandler requires getMasterBotSettings');
+    }
+    if (typeof sanitizeDiscordRedirectPath !== 'function') {
+        throw new TypeError('createDiscordOAuthStartHandler requires sanitizeDiscordRedirectPath');
+    }
+    if (typeof buildDiscordOAuthRedirectLocation !== 'function') {
+        throw new TypeError('createDiscordOAuthStartHandler requires buildDiscordOAuthRedirectLocation');
+    }
+    if (typeof redirectWithSession !== 'function') {
+        throw new TypeError('createDiscordOAuthStartHandler requires redirectWithSession');
+    }
+    if (typeof randomState !== 'function') {
+        throw new TypeError('createDiscordOAuthStartHandler requires randomState');
+    }
+    const resolvedAuthorizeUrl =
+        typeof authorizeUrl === 'string' && authorizeUrl
+            ? authorizeUrl
+            : 'https://discord.com/oauth2/authorize';
+    const resolvedScopes = Array.isArray(scopes) && scopes.length > 0 ? scopes : ['identify', 'guilds'];
+
+    return async function discordOAuthStartHandler(req, res) {
+        try {
+            const settings = await getMasterBotSettings();
+            const clientId =
+                typeof settings?.oauthClientId === 'string' && settings.oauthClientId
+                    ? settings.oauthClientId
+                    : typeof settings?.oauth?.clientId === 'string'
+                        ? settings.oauth.clientId
+                        : '';
+            const redirectUrl =
+                typeof settings?.oauthRedirectUri === 'string' && settings.oauthRedirectUri
+                    ? settings.oauthRedirectUri
+                    : typeof settings?.oauth?.redirectUrl === 'string'
+                        ? settings.oauth.redirectUrl
+                        : '';
+
+            const redirectParam = Array.isArray(req.query?.redirect)
+                ? req.query.redirect[0]
+                : req.query?.redirect;
+            const redirectPath = sanitizeDiscordRedirectPath(redirectParam);
+
+            if (!clientId || !redirectUrl) {
+                const location = buildDiscordOAuthRedirectLocation({
+                    error: 'discord_oauth_not_configured',
+                    redirect: redirectPath,
+                });
+                await redirectWithSession(req, res, location);
+                return;
+            }
+
+            const state = randomState();
+            if (typeof state !== 'string' || !state) {
+                throw new TypeError('randomState must return a non-empty string');
+            }
+            req.session.discordOAuth = {
+                state,
+                createdAt: Date.now(),
+                ...(redirectPath ? { redirect: redirectPath } : {}),
+            };
+
+            const authorize = new URL(resolvedAuthorizeUrl);
+            authorize.searchParams.set('response_type', 'code');
+            authorize.searchParams.set('client_id', clientId);
+            authorize.searchParams.set('scope', resolvedScopes.join(' '));
+            authorize.searchParams.set('redirect_uri', redirectUrl);
+            authorize.searchParams.set('state', state);
+            authorize.searchParams.set('prompt', 'consent');
+
+            await redirectWithSession(req, res, authorize.toString());
+        } catch (err) {
+            logger?.error?.('Failed to initiate Discord OAuth flow.', err);
+            res.status(500).json({ error: 'discord_oauth_start_failed' });
+        }
+    };
+}
+
+export default createDiscordOAuthStartHandler;

--- a/server/server.js
+++ b/server/server.js
@@ -39,6 +39,7 @@ import {
     buildDiscordOAuthRedirectLocation,
     sanitizeDiscordRedirectPath,
 } from './lib/discordOAuthRedirect.js';
+import { createDiscordOAuthStartHandler } from './routes/discordOAuthStart.handler.js';
 import { DEFAULT_WORLD_SKILLS } from '../shared/worldSkills.js';
 import { findCombatSkillById, findCombatSkillByName } from '../shared/combatSkills.js';
 import { MUSIC_TRACKS, getMusicTrack } from '../shared/music/index.js';
@@ -6085,52 +6086,18 @@ async function redirectWithSession(req, res, location) {
     return true;
 }
 
-app.get('/api/auth/discord/start', async (req, res) => {
-    try {
-        const settings = await getMasterBotSettings();
-        const clientId =
-            typeof settings.oauthClientId === 'string' && settings.oauthClientId
-                ? settings.oauthClientId
-                : typeof settings.oauth?.clientId === 'string'
-                    ? settings.oauth.clientId
-                    : '';
-        const redirectUrl =
-            typeof settings.oauthRedirectUri === 'string' && settings.oauthRedirectUri
-                ? settings.oauthRedirectUri
-                : typeof settings.oauth?.redirectUrl === 'string'
-                    ? settings.oauth.redirectUrl
-                    : '';
-
-        if (!clientId || !redirectUrl) {
-            return res.status(400).json({ error: 'discord_oauth_not_configured' });
-        }
-
-        const redirectParam = Array.isArray(req.query?.redirect)
-            ? req.query.redirect[0]
-            : req.query?.redirect;
-        const redirectPath = sanitizeDiscordRedirectPath(redirectParam);
-
-        const state = crypto.randomBytes(16).toString('hex');
-        req.session.discordOAuth = {
-            state,
-            createdAt: Date.now(),
-            ...(redirectPath ? { redirect: redirectPath } : {}),
-        };
-
-        const authorizeUrl = new URL(DISCORD_OAUTH_AUTHORIZE_URL);
-        authorizeUrl.searchParams.set('response_type', 'code');
-        authorizeUrl.searchParams.set('client_id', clientId);
-        authorizeUrl.searchParams.set('scope', DISCORD_OAUTH_SCOPES.join(' '));
-        authorizeUrl.searchParams.set('redirect_uri', redirectUrl);
-        authorizeUrl.searchParams.set('state', state);
-        authorizeUrl.searchParams.set('prompt', 'consent');
-
-        await redirectWithSession(req, res, authorizeUrl.toString());
-    } catch (err) {
-        discordLogger.error('Failed to initiate Discord OAuth flow.', err);
-        res.status(500).json({ error: 'discord_oauth_start_failed' });
-    }
+const discordOAuthStartHandler = createDiscordOAuthStartHandler({
+    getMasterBotSettings,
+    sanitizeDiscordRedirectPath,
+    buildDiscordOAuthRedirectLocation,
+    redirectWithSession,
+    randomState: () => crypto.randomBytes(16).toString('hex'),
+    logger: discordLogger,
+    authorizeUrl: DISCORD_OAUTH_AUTHORIZE_URL,
+    scopes: DISCORD_OAUTH_SCOPES,
 });
+
+app.get('/api/auth/discord/start', discordOAuthStartHandler);
 
 app.get('/api/auth/discord/callback', async (req, res) => {
     const queryError = typeof req.query?.error === 'string' ? req.query.error : '';


### PR DESCRIPTION
## Summary
- reuse `redirectWithSession` when Discord OAuth is not configured so `/api/auth/discord/start` redirects with a sanitized fallback
- extract the Discord OAuth start logic into a dedicated handler to share between runtime code and tests
- add a regression test that covers the not-configured flow and ensures the redirect points to `/login?discordError=discord_oauth_not_configured`

## Testing
- npm test *(fails: vitest executable not found because dependencies are unavailable in the environment)*
- npm install *(fails: registry returned 403 for @vitejs/plugin-vue)*

------
https://chatgpt.com/codex/tasks/task_e_68f6dd15bbb48331b3984ac4e281b89e